### PR TITLE
Added some dotfile creation + test embryo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 node_modules
+test/temp
+

--- a/app/index.js
+++ b/app/index.js
@@ -1,7 +1,7 @@
 
 var util = require('util'),
     path = require('path'),
-    yeoman = require('../../../../');
+    yeoman = require('yeoman');
 
 module.exports = Generator;
 
@@ -9,12 +9,16 @@ function Generator() {
   yeoman.generators.Base.apply(this, arguments);
 
   this.test_framework = this.options['test-framework'] || 'mocha';
-  this.hookFor('test-framework', { as: 'app' });
+  // this.hookFor('test-framework', { as: 'app' });
 }
 
 util.inherits(Generator, yeoman.generators.Base);
 
 Generator.prototype.setupEnv = function setupEnv() {
+   // Copies the contents of the generator `templates`
+  // directory into your users new application path
+  this.sourceRoot(path.join(__dirname, 'templates'));
+
   this.directory('app/scripts/','app/scripts/', true);
   this.directory('app/styles/','app/styles/', true);
   this.template('app/.buildignore');
@@ -37,6 +41,18 @@ Generator.prototype.gruntfile = function gruntfile() {
     this.template('Gruntfile.js');
   }
 };
+
+Generator.prototype.bowerrc = function bowerrc() {
+  this.copy('.bowerrc', '.bowerrc');
+}
+
+Generator.prototype.editorconfig = function editorconfig() {
+  this.copy('.editorconfig', '.editorconfig');
+}
+
+Generator.prototype.jshintrc = function jshintrc() {
+  this.copy('.jshintrc', '.jshintrc');
+}
 
 Generator.prototype.packageJSON = function packageJSON() {
   this.template('package.json');

--- a/app/templates/.bowerrc
+++ b/app/templates/.bowerrc
@@ -1,0 +1,3 @@
+{
+    "directory": "app/components"
+}

--- a/app/templates/.editorconfig
+++ b/app/templates/.editorconfig
@@ -1,0 +1,18 @@
+# EditorConfig helps developers define and maintain consistent
+# coding styles between different editors and IDEs
+# editorconfig.org
+
+root = true
+
+
+[*]
+
+# Change these settings to your own preference
+indent_style = space
+indent_size = 4
+
+# We recommend you to keep these unchanged
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true

--- a/app/templates/.jshintrc
+++ b/app/templates/.jshintrc
@@ -1,0 +1,22 @@
+{
+    "node": true,
+    "browser": true,
+    "es5": true,
+    "esnext": true,
+    "bitwise": true,
+    "camelcase": true,
+    "curly": true,
+    "eqeqeq": true,
+    "immed": true,
+    "indent": 4,
+    "latedef": true,
+    "newcap": true,
+    "noarg": true,
+    "quotmark": "single",
+    "regexp": true,
+    "undef": true,
+    "unused": true,
+    "strict": true,
+    "trailing": true,
+    "smarttabs": true
+}

--- a/package.json
+++ b/package.json
@@ -20,7 +20,9 @@
   "scripts": {
     "test": "node node_modules/mocha/bin/mocha test/test-*.js"
   },
-  "dependencies": {},
+  "dependencies": {
+    "yeoman": "~0.9.5"
+    },
   "devDependencies": {
     "mocha": "~1.7.1"
   },

--- a/test/test-file-creation.js
+++ b/test/test-file-creation.js
@@ -1,0 +1,26 @@
+var assert = require("assert");
+var Generator = require("../app");
+var fs = require("fs");
+var path = require("path");
+var assert = require("assert");
+var yeoman = require('yeoman').generators.test;
+
+describe("Backbone generator", function() {
+  before(yeoman.before(path.join(__dirname, 'temp')));
+
+  it ("should generate dotfiles", function() {
+    // FIXME: Remove the Gruntfile.js created by the test.before function
+    fs.unlinkSync("Gruntfile.js");
+
+    var g = new Generator();
+    g.run();
+
+    yeoman.assertFile(".bowerrc");
+    yeoman.assertFile(".gitignore");
+    yeoman.assertFile(".editorconfig");
+    yeoman.assertFile(".jshintrc");
+
+  });
+
+});
+


### PR DESCRIPTION
`.bowerrc` should be created now (with `.editorconfig` and `.jshintrc`).

Note though that I've an issue with the registred hook `test-framework`: using it makes the test blew up ...
This is mainly due from my point of view because the `base.js` `runHooks`, will try to call `invoke` on the generator.
However, there's no `invoke` method in `base.js`, it is only present in `generators.js`. I guess that it is mixed in `Base` by `yeoman init`, but need to check more.
