### PR TITLE
ClassCase for Views

### DIFF
--- a/templates/coffeescript/view.coffee
+++ b/templates/coffeescript/view.coffee
@@ -1,1 +1,1 @@
-class <%= grunt.util._.camelize(appname) %>.Views.<%= grunt.util._.camelize(name) %>View extends Backbone.View
+class <%= grunt.util._.camelize(appname) %>.Views.<%= grunt.util._.classify(name) %>View extends Backbone.View

--- a/templates/view.js
+++ b/templates/view.js
@@ -1,4 +1,4 @@
-<%= grunt.util._.camelize(appname) %>.Views.<%= grunt.util._.camelize(name) %>View = Backbone.View.extend({
+<%= grunt.util._.camelize(appname) %>.Views.<%= grunt.util._.classify(name) %>View = Backbone.View.extend({
 
   //template: <%= grunt.util._.underscored(name) %>
 


### PR DESCRIPTION
The current view generator adds the class to your Views scope in camel case which is inconsistent with Models and Collections. This commit corrects that. : )

App.Models.FooModel = Back….
App.Collections.FooCollection = Back….
App.Views.FooView = Back….
