### PR TITLE
setting mocha as default test-framework

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -8,7 +8,7 @@ function Generator() {
   yeoman.generators.Base.apply(this, arguments);
 
   this.testFramework = this.options['test-framework'] || 'mocha';
-  this.hookFor('test-framework', { as: 'app' });
+  this.hookFor(this.testFramework , { as: 'app' });
 }
 
 util.inherits(Generator, yeoman.generators.Base);


### PR DESCRIPTION
Fixes the issue

`Invalid namespace: test-framework:app (or not yet registered). 
Registered: 11 namespace(s). Run with the `--help` option to list them.`

when we execute **yeoman init backbone**
