### PR TITLE
yeoman won't trigger bower install fix #11

### DIFF
--- a/all/index.js
+++ b/all/index.js
@@ -37,6 +37,10 @@ function Generator() {
   this.hookFor('backbone:collection', {
     args: args
   });
+
+  this.on('end', function () {
+    console.log('\nI\'m all done. Just run ' + 'npm install && bower install'.bold.yellow + ' to install the required dependencies.');
+  });
 }
 
 util.inherits(Generator, yeoman.generators.Base);

--- a/app/index.js
+++ b/app/index.js
@@ -9,6 +9,12 @@ function Generator() {
 
   this.testFramework = this.options['test-framework'] || 'mocha';
   this.hookFor(this.testFramework , { as: 'app' });
+
+  this.on('end', function () {
+    if(this.generatorName === 'app'){
+      console.log('\nI\'m all done. Just run ' + 'npm install && bower install'.bold.yellow + ' to install the required dependencies.');
+    }
+  });
 }
 
 util.inherits(Generator, yeoman.generators.Base);
@@ -32,11 +38,6 @@ Generator.prototype.git = function git() {
 Generator.prototype.bower = function bower() {
   this.copy('bowerrc', '.bowerrc');
   this.copy('component.json', 'component.json');
-  this.install('', function (err) {
-    if (err) {
-      console.error(err);
-    }
-  });
 };
 
 Generator.prototype.jshint = function jshint() {


### PR DESCRIPTION
- The user should trigger bower install explicitly.
- Added a message after the scaffolding
  "I'm all done. Just run npm install && bower install to install the required dependencies."
