### PR TITLE
Fix for issue #27: Tests failing in node 0.10

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -15,7 +15,7 @@ function Generator(args, options, config) {
 
   this.on('end', function () {
     if (['app', 'backbone'].indexOf(this.generatorName) >= 0) {
-      this.installDependencies({ skipInstall: options['skip-install'] });
+      this.installDependencies({ skipInstall: this.options['skip-install'] });
     }
   });
 }

--- a/test/test-foo.js
+++ b/test/test-foo.js
@@ -42,6 +42,7 @@ describe('Backbone generator test', function () {
           'mocha:app'
         ]
       ]);
+      this.backbone.app.options['skip-install'] = true;
       done();
     }.bind(this));
 

--- a/test/test-requirejs.js
+++ b/test/test-requirejs.js
@@ -17,6 +17,7 @@ describe('Backbone generator with RequireJS', function () {
           'mocha:app'
         ]
       ]);
+      this.backbone.app.options['skip-install'] = true;
       done();
     }.bind(this));
 


### PR DESCRIPTION
This fixes issue #27 by adding skip-install to the tests, and by fixing app/index.js to use the options.

[This is a single feature pull request - master contains this feature already]
