### PR TITLE
Ensure generated JST templates are added to the built distribution

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -105,10 +105,6 @@ Generator.prototype.mainStylesheet = function mainStylesheet() {
   }
 };
 
-Generator.prototype.jstTemplates = function jstTemplates() {
-  this.copy('templates.js', 'app/scripts/templates.js');
-};
-
 Generator.prototype.writeIndex = function writeIndex() {
   if (this.includeRequireJS) {
     return;

--- a/app/templates/Gruntfile.js
+++ b/app/templates/Gruntfile.js
@@ -161,6 +161,9 @@ module.exports = function (grunt) {
                     // `name` and `out` is set by grunt-usemin
                     baseUrl: 'app/scripts',
                     optimize: 'none',
+                    paths: {
+                        'templates': '../../.tmp/scripts/templates'
+                    },
                     // TODO: Figure out how to make sourcemaps work with grunt-usemin
                     // https://github.com/yeoman/grunt-usemin/issues/30
                     //generateSourceMaps: true,
@@ -177,7 +180,8 @@ module.exports = function (grunt) {
             dist: {
                 files: {
                     '<%%= yeoman.dist %>/scripts/main.js': [
-                        '<%%= yeoman.app %>/scripts/{,*/}*.js'
+                        '<%%= yeoman.app %>/scripts/{,*/}*.js',
+                        '.tmp/scripts/templates.js'
                     ],
                 }
             }
@@ -237,6 +241,14 @@ module.exports = function (grunt) {
             }
         },
         copy: {
+            defaultTemplate: {
+                files: [{
+                    expand: true,
+                    cwd: require('path').dirname(require.resolve('generator-backbone/app/templates/templates.js')),
+                    dest: '.tmp/scripts/',
+                    src: [ 'templates.js' ]
+                }]
+            },
             dist: {
                 files: [{
                     expand: true,
@@ -278,6 +290,7 @@ module.exports = function (grunt) {
         grunt.task.run([
             'clean:server',
             'coffee:dist',
+            'copy:defaultTemplate',
             'jst',
             'compass:server',
             'livereload-start',
@@ -290,6 +303,7 @@ module.exports = function (grunt) {
     grunt.registerTask('test', [
         'clean:server',
         'coffee',
+        'copy:defaultTemplate',
         'jst',
         'compass',
         'connect:test',
@@ -299,6 +313,7 @@ module.exports = function (grunt) {
     grunt.registerTask('build', [
         'clean:dist',
         'coffee',
+        'copy:defaultTemplate',
         'jst',
         'compass:dist',
         'useminPrepare',<% if (includeRequireJS) { %>
@@ -308,7 +323,7 @@ module.exports = function (grunt) {
         'concat',
         'cssmin',
         'uglify',
-        'copy',
+        'copy:dist',
         'usemin'
     ]);
 

--- a/test/test-foo.js
+++ b/test/test-foo.js
@@ -76,7 +76,6 @@ describe('Backbone generator test', function () {
       '.editorconfig',
       'Gruntfile.js',
       'package.json',
-      'app/scripts/templates.js'
     ];
 
     helpers.mockPrompt(this.backbone.app, {

--- a/test/test-requirejs.js
+++ b/test/test-requirejs.js
@@ -42,7 +42,6 @@ describe('Backbone generator with RequireJS', function () {
         '.editorconfig',
         'Gruntfile.js',
         'package.json',
-        'app/scripts/templates.js',
         'app/scripts/vendor/bootstrap.js',
         ['app/scripts/main.js', /bootstrap/]
       ];
@@ -77,7 +76,6 @@ describe('Backbone generator with RequireJS', function () {
         '.editorconfig',
         'Gruntfile.js',
         'package.json',
-        'app/scripts/templates.js'
       ];
 
       helpers.mockPrompt(this.backbone.app, {


### PR DESCRIPTION
These fixes ensure that the generated JST templates are added to dist. It also removes the default templates.js from the app/scripts folder - providing it only if JST doesn't generate any  templates.

[This is single feature pull request - zeripath/master contains these commits already]
