### PR TITLE
Refix app templates make out-of-the box grunt for non-AMD work

### DIFF
--- a/templates/app.js
+++ b/templates/app.js
@@ -1,4 +1,4 @@
-/*global <%= _.camelize(appname) %> $*/
+/*global <%= _.camelize(appname) %>, $*/
 'use strict';
 
 

--- a/templates/collection.js
+++ b/templates/collection.js
@@ -1,4 +1,4 @@
-/*global <%= _.camelize(appname) %> Backbone*/
+/*global <%= _.camelize(appname) %>, Backbone*/
 
 <%= _.camelize(appname) %>.Collections.<%= _.classify(name) %>Collection = Backbone.Collection.extend({
 

--- a/templates/model.js
+++ b/templates/model.js
@@ -1,4 +1,4 @@
-/*global <%= _.camelize(appname) %> Backbone*/
+/*global <%= _.camelize(appname) %>, Backbone*/
 
 <%= _.camelize(appname) %>.Models.<%= _.classify(name) %>Model = Backbone.Model.extend({
 

--- a/templates/router.js
+++ b/templates/router.js
@@ -1,4 +1,4 @@
-/*global <%= _.camelize(appname) %> Backbone*/
+/*global <%= _.camelize(appname) %>, Backbone*/
 
 <%= _.camelize(appname) %>.Routers.<%= _.classify(name) %>Router = Backbone.Router.extend({
 

--- a/templates/view.js
+++ b/templates/view.js
@@ -1,4 +1,4 @@
-/*global <%= _.camelize(appname) %> Backbone JST*/
+/*global <%= _.camelize(appname) %>, Backbone, JST*/
 
 <%= _.camelize(appname) %>.Views.<%= _.classify(name) %>View = Backbone.View.extend({
 


### PR DESCRIPTION
The recent update to jshint 0.4.3 means that grunt no longer works out-of-the-box for non-require-amd builds. These commits fix the globals definitions to use comma-separated lists and remove a blank line from the generated Gruntfile.js.

[This is a single feature pull-request, zeripath/master already contains these commits]
