### PR TITLE
moved creating main.js from 'all' to 'app' sub generator

### DIFF
--- a/all/index.js
+++ b/all/index.js
@@ -38,7 +38,7 @@ function Generator(args, options, config) {
   });
 
   this.on('end', function () {
-    this.installDependencies({ skipInstall: options['skip-install'] });
+    this.installDependencies({ skipInstall: this.options['skip-install'] });
   });
 }
 
@@ -51,9 +51,3 @@ Generator.prototype.createDirLayout = function createDirLayout() {
     this.mkdir(path.join('app/scripts', dir));
   }.bind(this));
 };
-
-Generator.prototype.createAppFile = function createAppFile() {
-  var ext = this.options.coffee ? 'coffee' : 'js';
-  this.template('app.' + ext, 'app/scripts/main.' + ext);
-};
-

--- a/app/index.js
+++ b/app/index.js
@@ -291,3 +291,11 @@ Generator.prototype.mainJs = function mainJs() {
 
   this.write('app/scripts/main.js', mainJsFile.join('\n'));
 };
+
+Generator.prototype.createAppFile = function createAppFile() {
+  var dirPath = this.options.coffee ? '../templates/coffeescript/' : '../templates';
+  this.sourceRoot(path.join(__dirname, dirPath));
+
+  var ext = this.options.coffee ? 'coffee' : 'js';
+  this.template('app.' + ext, 'app/scripts/main.' + ext);
+};

--- a/test/test-foo.js
+++ b/test/test-foo.js
@@ -76,6 +76,7 @@ describe('Backbone generator test', function () {
       '.editorconfig',
       'Gruntfile.js',
       'package.json',
+      'app/scripts/main.js',
     ];
 
     helpers.mockPrompt(this.backbone.app, {


### PR DESCRIPTION
If this is not moved, all the subgenerator like controller, model etc will throw error.
All those sub generators use **isUsingRequireJS** method which will try to read main.js
