### PR TITLE
Add alternate template generators for mustache and handlebars

### DIFF
--- a/all/index.js
+++ b/all/index.js
@@ -20,6 +20,14 @@ function Generator(args, options, config) {
     args.push('--coffee');
   }
 
+  if (this.options['template-framework']) {
+    this.env.options['template-framework'] = this.options['template-framework'];
+  }
+
+  if (this.options['test-framework']) {
+    this.env.options['test-framework'] = this.options['test-framework'];
+  }
+
   // the api to hookFor and pass arguments may vary a bit.
   this.hookFor('backbone:app', {
     args: args

--- a/app/index.js
+++ b/app/index.js
@@ -9,6 +9,7 @@ function Generator(args, options, config) {
   yeoman.generators.Base.apply(this, arguments);
 
   this.testFramework = this.options['test-framework'] || 'mocha';
+  this.templateFramework = this.options['template-framework'] || 'lodash';
   this.hookFor(this.testFramework, { as: 'app' });
 
   this.indexFile = this.readFileAsString(path.join(this.sourceRoot(), 'index.html'));
@@ -293,6 +294,9 @@ Generator.prototype.mainJs = function mainJs() {
 };
 
 Generator.prototype.createAppFile = function createAppFile() {
+  if (this.includeRequireJS) {
+    return;
+  }
   var dirPath = this.options.coffee ? '../templates/coffeescript/' : '../templates';
   this.sourceRoot(path.join(__dirname, dirPath));
 

--- a/app/templates/Gruntfile.js
+++ b/app/templates/Gruntfile.js
@@ -9,6 +9,7 @@ var mountFolder = function (connect, dir) {
 // 'test/spec/{,*/}*.js'
 // use this if you want to match all subfolders:
 // 'test/spec/**/*.js'
+// templateFramework: '<%= templateFramework %>'
 
 module.exports = function (grunt) {
     // load all grunt tasks
@@ -43,13 +44,25 @@ module.exports = function (grunt) {
                     '<%%= yeoman.app %>/images/{,*/}*.{png,jpg,jpeg,gif,webp}'
                 ],
                 tasks: ['livereload']
-            },
+            },<% if (templateFramework === 'mustache') { %>
+            mustache: {
+                files: [
+                    '<%%= yeoman.app %>/scripts/templates/*.mustache'
+                ],
+                tasks: ['mustache']
+            }<% } else if (templateFramework === 'handlebars') { %>
+            handlebars: {
+                files: [
+                    '<%%= yeoman.app %>/scripts/templates/*.hbs'
+                ],
+                tasks: ['handlebars']
+            }<% } else { %>
             jst: {
                 files: [
                     '<%%= yeoman.app %>/scripts/templates/*.ejs'
                 ],
                 tasks: ['jst']
-            }
+            }<% } %>
         },
         connect: {
             options: {
@@ -266,7 +279,30 @@ module.exports = function (grunt) {
             all: {
                 rjsConfig: '<%%= yeoman.app %>/scripts/main.js'
             }
-        },
+        },<% if (templateFramework === 'mustache') { %>
+        mustache: {
+            files: {
+                src: '<%%= yeoman.app %>/scripts/templates/',
+                dest: '.tmp/scripts/templates.js',
+                options: {<% if (includeRequireJS) { %>
+                    prefix: 'define(function() { this.JST = ',
+                    postfix: '; return this.JST;});'<% } else { %>
+                    prefix: 'this.JST = ',
+                    postfix: ';'<% } %>
+                }
+            }
+        }<% } else if (templateFramework === 'handlebars') { %>
+        handlebars: {
+            compile: {
+                options: {
+                    namespace: 'JST'<% if (includeRequireJS) { %>,
+                    amd: true<% } %>
+                },
+                files: {
+                    '.tmp/scripts/templates.js': ['<%%= yeoman.app %>/scripts/templates/*.hbs']
+                }
+            }
+        }<% } else { %>
         jst: {<% if (includeRequireJS) { %>
             options: {
                 amd: true
@@ -276,7 +312,7 @@ module.exports = function (grunt) {
                     '.tmp/scripts/templates.js': ['<%%= yeoman.app %>/scripts/templates/*.ejs']
                 }
             }
-        }
+        }<% } %>
     });
 
     grunt.renameTask('regarde', 'watch');
@@ -289,8 +325,10 @@ module.exports = function (grunt) {
         grunt.task.run([
             'clean:server',
             'coffee:dist',
-            'copy:defaultTemplate',
-            'jst',
+            'copy:defaultTemplate',<% if (templateFramework === 'mustache') { %>
+            'mustache',<% } else if (templateFramework === 'handlebars') { %>
+            'handlebars',<% } else { %>
+            'jst',<% } %>
             'compass:server',
             'livereload-start',
             'connect:livereload',
@@ -302,8 +340,10 @@ module.exports = function (grunt) {
     grunt.registerTask('test', [
         'clean:server',
         'coffee',
-        'copy:defaultTemplate',
-        'jst',
+        'copy:defaultTemplate',<% if (templateFramework === 'mustache' ) { %>
+        'mustache',<% } else if (templateFramework === 'handlebars') { %>
+        'handlebars',<% } else { %>
+        'jst',<% } %>
         'compass',
         'connect:test',
         'mocha'
@@ -312,8 +352,10 @@ module.exports = function (grunt) {
     grunt.registerTask('build', [
         'clean:dist',
         'coffee',
-        'copy:defaultTemplate',
-        'jst',
+        'copy:defaultTemplate',<% if (templateFramework === 'mustache' ) { %>
+        'mustache',<% } else if (templateFramework === 'handlebars') { %>
+        'handlebars',<% } else { %>
+        'jst',<% } %>
         'compass:dist',
         'useminPrepare',<% if (includeRequireJS) { %>
         'requirejs',<% } %>

--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -6,8 +6,10 @@
     "grunt": "~0.4.1",
     "grunt-contrib-copy": "~0.4.0",
     "grunt-contrib-concat": "~0.2.0",
-    "grunt-contrib-coffee": "~0.6.6",
-    "grunt-contrib-jst": "~0.5.0",
+    "grunt-contrib-coffee": "~0.6.6",<% if (templateFramework === 'mustache') { %>
+    "grunt-mustache": "~0.1.4",<% } else if (templateFramework === 'handlebars') { %>
+    "grunt-contrib-handlebars": "~0.5.8",<% } else { %>
+    "grunt-contrib-jst": "~0.5.0",<% } %>
     "grunt-contrib-uglify": "~0.2.0",
     "grunt-contrib-compass": "~0.2.0",
     "grunt-contrib-jshint": "~0.4.3",

--- a/readme.md
+++ b/readme.md
@@ -45,6 +45,10 @@ Available generators:
   Defaults to `mocha`. Can be switched for
   another supported testing framework like `jasmine`.
 
+* `--template-framework=[framework]`
+
+  Defaults to `lodash` templating with grunt-contrib-jst.
+  `handlebars` and `mustache` are also supported.
 
 ## Contribute
 

--- a/script-base.js
+++ b/script-base.js
@@ -59,3 +59,16 @@ Generator.prototype.isUsingRequireJS = function isUsingRequireJS() {
   var ext = this.env.options.coffee ? '.coffee' : '.js';
   return (/require\.config/).test(this.read(path.join(process.cwd(), 'app/scripts/main' + ext)));
 };
+
+Generator.prototype.getTemplateFramework = function getTemplateFramework () {
+  if (!(require('fs').existsSync(path.join(process.cwd(), 'Gruntfile.js')))) {
+    return 'lodash';
+  }
+  var ftest = (/templateFramework: '([^\']*)'/);
+  var match = ftest.exec(this.read(path.join(process.cwd(), 'Gruntfile.js')));
+  if (match) {
+    return match[1];
+  } else {
+    return 'lodash';
+  }
+};

--- a/view/index.js
+++ b/view/index.js
@@ -17,10 +17,16 @@ util.inherits(Generator, scriptBase);
 
 Generator.prototype.createViewFiles = function createViewFiles() {
   var ext = this.options.coffee ? 'coffee' : 'js';
-  this.jst_path = path.join('app/scripts/templates', this.name + '.ejs');
+  var templateFramework = this.getTemplateFramework();
+  var templateExt = '.ejs';
+  if (templateFramework === 'mustache') {
+    templateExt = '.mustache';
+  } else if (templateFramework === 'handlebars') {
+    templateExt = '.hbs';
+  }
+  this.jst_path = path.join('app/scripts/templates', this.name + templateExt);
   var destFile = path.join('app/scripts/views', this.name + '-view.' + ext);
   var isRequireJsApp = this.isUsingRequireJS();
-
 
   this.template('view.ejs', this.jst_path);
   if(!isRequireJsApp){


### PR DESCRIPTION
In the comments of #20 @revathskumar asks how we could enable users of the backbone generator to use other templating engines. This patch adds pre-compilation templating for handlebars and mustache.
