### PR TITLE
Fix broken test-framework option

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -88,7 +88,7 @@ Generator.prototype.editorConfig = function editorConfig() {
 
 Generator.prototype.gruntfile = function gruntfile() {
   if (this.testFramework === 'jasmine') {
-    this.write('Gruntfile.js', this.engine(this.read('Gruntfile.js')).replace(/mocha/g, 'jasmine'));
+    this.write('Gruntfile.js', this.engine(this.read('Gruntfile.js'), this).replace(/mocha/g, 'jasmine'));
   } else {
     this.template('Gruntfile.js');
   }


### PR DESCRIPTION
I've noted that the test-framework option has been broken since at least the includeRequestJS option was added (Including in 0.1.0). This branch fixes this by passing the generator itself as the data argument into the templating engine when generating the Gruntfile.
