### PR TITLE
Bug fix automatic generation of mustache templates.

### DIFF
--- a/view/index.js
+++ b/view/index.js
@@ -20,7 +20,7 @@ Generator.prototype.createViewFiles = function createViewFiles() {
   var templateFramework = this.getTemplateFramework();
   var templateExt = '.ejs';
   if (templateFramework === 'mustache') {
-    templateExt = '.mustache';
+    templateExt = '-template.mustache';
   } else if (templateFramework === 'handlebars') {
     templateExt = '.hbs';
   }
@@ -29,7 +29,10 @@ Generator.prototype.createViewFiles = function createViewFiles() {
   var isRequireJsApp = this.isUsingRequireJS();
 
   this.template('view.ejs', this.jst_path);
-  if(!isRequireJsApp){
+  if (templateFramework === 'mustache') {
+    this.jst_path = this.name + '-template';
+  }
+  if (!isRequireJsApp) {
     this.template('view.' + ext, destFile);
     this.addScriptToIndex('views/' + this.name + '-view');
     return;


### PR DESCRIPTION
Sorry about this guys, I've just realised that the mustache template generation patch I created wasn't quite right. Grunt-mustache works slightly differently from grunt-contrib-jst and grunt-contrib-handlebars, in that it creates a JST hash with keys only of the relative filename. This patch fixes this by adjusting the key referenced in the auto-generated views. (There is a slight hack in that it adds the suffix '-template' to the template names to workaround jshint complaining about JST['oneWord'] but not JST['two-words'].)
