### PR TITLE
Fixes #44 - Can't use require on global packages

### DIFF
--- a/app/templates/Gruntfile.js
+++ b/app/templates/Gruntfile.js
@@ -253,14 +253,6 @@ module.exports = function (grunt) {
             }
         },
         copy: {
-            defaultTemplate: {
-                files: [{
-                    expand: true,
-                    cwd: require('path').dirname(require.resolve('generator-backbone/app/templates/templates.js')),
-                    dest: '.tmp/scripts/',
-                    src: [ 'templates.js' ]
-                }]
-            },
             dist: {
                 files: [{
                     expand: true,
@@ -317,6 +309,10 @@ module.exports = function (grunt) {
 
     grunt.renameTask('regarde', 'watch');
 
+    grunt.registerTask('createDefaultTemplate', function () {
+        grunt.file.write('.tmp/scripts/templates.js', 'this.JST = this.JST || {};');
+    });
+
     grunt.registerTask('server', function (target) {
         if (target === 'dist') {
             return grunt.task.run(['build', 'open', 'connect:dist:keepalive']);
@@ -325,7 +321,7 @@ module.exports = function (grunt) {
         grunt.task.run([
             'clean:server',
             'coffee:dist',
-            'copy:defaultTemplate',<% if (templateFramework === 'mustache') { %>
+            'createDefaultTemplate',<% if (templateFramework === 'mustache') { %>
             'mustache',<% } else if (templateFramework === 'handlebars') { %>
             'handlebars',<% } else { %>
             'jst',<% } %>
@@ -340,7 +336,7 @@ module.exports = function (grunt) {
     grunt.registerTask('test', [
         'clean:server',
         'coffee',
-        'copy:defaultTemplate',<% if (templateFramework === 'mustache' ) { %>
+        'createDefaultTemplate',<% if (templateFramework === 'mustache' ) { %>
         'mustache',<% } else if (templateFramework === 'handlebars') { %>
         'handlebars',<% } else { %>
         'jst',<% } %>
@@ -352,7 +348,7 @@ module.exports = function (grunt) {
     grunt.registerTask('build', [
         'clean:dist',
         'coffee',
-        'copy:defaultTemplate',<% if (templateFramework === 'mustache' ) { %>
+        'createDefaultTemplate',<% if (templateFramework === 'mustache' ) { %>
         'mustache',<% } else if (templateFramework === 'handlebars') { %>
         'handlebars',<% } else { %>
         'jst',<% } %>
@@ -364,7 +360,7 @@ module.exports = function (grunt) {
         'concat',
         'cssmin',
         'uglify',
-        'copy:dist',
+        'copy',
         'usemin'
     ]);
 

--- a/app/templates/templates.js
+++ b/app/templates/templates.js
@@ -1,1 +1,0 @@
-this.JST = this.JST || {};


### PR DESCRIPTION
This patch will simply create the default templates file using grunt.file.write instead of copying it from the package.

I hope this is acceptable, it seems more sensible than having the default templates file in the source which could be confusing.  I have deleted the old default templates file as it is not required any more.
