### PR TITLE
Enable jQuery option for JSHint

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -16,5 +16,6 @@
   "smarttabs"    : true,
   "quotmark"     : "single",
   "indent"       : 2,
-  "white"        : true
+  "white"        : true,
+  "jquery"       : true
 }


### PR DESCRIPTION
Since most projects will use jQuery/Zepto together with Backbone.js.
