### PR TITLE
Mount app folder after test folder while testing

### DIFF
--- a/app/templates/Gruntfile.js
+++ b/app/templates/Gruntfile.js
@@ -86,8 +86,8 @@ module.exports = function (grunt) {
                     middleware: function (connect) {
                         return [
                             mountFolder(connect, '.tmp'),
-                            mountFolder(connect, yeomanConfig.app),
-                            mountFolder(connect, 'test')
+                            mountFolder(connect, 'test'),
+                            mountFolder(connect, yeomanConfig.app)
                         ];
                     }
                 }


### PR DESCRIPTION
Sorry for that. Didn't notice that the order mattered until I tried testing today and got "Warning: PhantomJS timed out, possibly due to a missing Mocha run() call.". Seems the app index.html is pulled first instead of the test one and breaks things, if I understand correctly?
