### PR TITLE
Fixes #57

### DIFF
--- a/app/templates/Gruntfile.js
+++ b/app/templates/Gruntfile.js
@@ -137,7 +137,7 @@ module.exports = function (grunt) {
                     // require them into your main .coffee file
                     expand: true,
                     cwd: '<%%= yeoman.app %>/scripts',
-                    src: '*.coffee',
+                    src: '{,*/}*.coffee',
                     dest: '.tmp/scripts',
                     ext: '.js'
                 }]
@@ -194,7 +194,7 @@ module.exports = function (grunt) {
                 files: {
                     '<%%= yeoman.dist %>/scripts/main.js': [
                         '<%%= yeoman.app %>/scripts/{,*/}*.js',
-                        '.tmp/scripts/templates.js'
+                        '.tmp/scripts/{,*/}*.js'
                     ]
                 }
             }


### PR DESCRIPTION
- Compile CoffeeScript from one-level subdirectories
- uglify all the js from .tmp
