### PR TITLE
Error in Gruntfile if template is Mustache

### DIFF
--- a/app/templates/Gruntfile.js
+++ b/app/templates/Gruntfile.js
@@ -47,7 +47,7 @@ module.exports = function (grunt) {
                     '{.tmp,<%%= yeoman.app %>}/scripts/{,*/}*.js',
                     '<%%= yeoman.app %>/images/{,*/}*.{png,jpg,jpeg,gif,webp}'
                 ]
-            }<% if (templateFramework === 'mustache') { %>
+            }<% if (templateFramework === 'mustache') { %>,
             mustache: {
                 files: [
                     '<%%= yeoman.app %>/scripts/templates/*.mustache'


### PR DESCRIPTION
There is a comma missing between "bower" and "mustache" tasks if one chooses Mustache as the template engine
