### PR TITLE
Use (and shim) core Backbone and Underscore Bower packages for scaffolding with RequireJS

### DIFF
--- a/app/templates/_bower.json
+++ b/app/templates/_bower.json
@@ -3,13 +3,11 @@
   "version": "0.0.0",
   "dependencies": {<% if (compassBootstrap) { %>
     "sass-bootstrap": "~2.3.0",<% } %>
-    "jquery": "~1.9.0",<% if (!includeRequireJS) { %>
+    "jquery": "~1.9.0",
     "underscore": "~1.4.3",
-    "backbone": "~1.0.0",<% }else{ %>
+    "backbone": "~1.0.0",<% if (includeRequireJS) { %>
     "requirejs": "~2.1.5",
-    "requirejs-text": "~2.0.5",
-    "backbone-amd": "~1.0.0",
-    "underscore-amd": "~1.4.4",<% } %>
+    "requirejs-text": "~2.0.5",<% } %>
     "modernizr": "~2.6.2"<% if (templateFramework === 'handlebars') { %>,
     "handlebars": "~1.0.0"<% } %>
   },

--- a/templates/requirejs_app.js
+++ b/templates/requirejs_app.js
@@ -23,8 +23,8 @@ require.config({
     },
     paths: {
         jquery: '../bower_components/jquery/jquery',
-        backbone: '../bower_components/backbone-amd/backbone',
-        underscore: '../bower_components/underscore-amd/underscore'<% if (compassBootstrap) { %>,
+        backbone: '../bower_components/backbone/backbone',
+        underscore: '../bower_components/underscore/underscore'<% if (compassBootstrap) { %>,
         bootstrap: 'vendor/bootstrap'<% } %><% if (templateFramework === 'handlebars') { %>,
         handlebars: '../bower_components/handlebars/handlebars'<% } %>
     }


### PR DESCRIPTION
Previously, when a user scaffolded a new app with this generator and chose to include RequireJS, AMD-compatible forks of Underscore and Backbone were installed by Bower (`backbone-amd` and `underscore-amd`), which were then (unnecessarily) shimmed by RequireJS in `main.js`. This pull request alters the generator to instead install the core non-amd Bower packages of Underscore and Backbone (`underscore` and `backbone`) and shim them in `main.js`.

Essentially, the original `shim` directives in `require.config` remain untouched, but the non-amd Bower packages of Underscore and Backbone (which require shimming to be used with RJS) are now used instead of the amd forks. This pull request makes no changes to scaffolding an app without RequireJS.

For the relevant discussion that led to this pull request, see this issue thread: https://github.com/yeoman/generator-backbone/issues/101

I've thoroughly tested this branch and everything seems to work great. However, full disclosure: when I run `npm test` in the forked repo, I receive the following npm error:

```
Backbone generator test
    &#10004; every generator can be required without throwing
    1) "before each" hook
x 1 of 12 tests failed:
1) Backbone generator test "before each" hook:
    Error: EBUSY, unlink 'path/to/generator-backbone/test/temp'

npm ERR! weird error 1
npm ERR! not ok code 0
```

This doesn't appear to be a failed test, but rather an npm problem on my machine. I'm not a Mocha expert unfortunately, so I can't verify this. If this represents a real problem with testing the repo, please let me know and I'll rectify it.
