### PR TITLE
Use consistent names for generated files

### DIFF
--- a/collection/index.js
+++ b/collection/index.js
@@ -17,12 +17,12 @@ function Generator() {
 util.inherits(Generator, scriptBase);
 
 Generator.prototype.createControllerFiles = function createControllerFiles() {
-  var ext = this.options.coffee ? 'coffee' : 'js';
-  var destFile = path.join('app/scripts/collections', this.name + '-collection.' + ext);
+  var ext = this.options.coffee ? '.coffee' : '.js';
+  var destFile = path.join('app/scripts/collections', this.name + ext);
   var isRequireJsApp = this.isUsingRequireJS();
 
   if (!isRequireJsApp) {
-    this.template('collection.' + ext, destFile);
+    this.template('collection' + ext, destFile);
     return;
   }
 
@@ -32,7 +32,7 @@ Generator.prototype.createControllerFiles = function createControllerFiles() {
     'define([',
     '    \'underscore\',',
     '    \'backbone\',',
-    '    \'models/' + this.name + '-model\'',
+    '    \'models/' + this.name + '\'',
     '], function (_, Backbone, ' + this._.classify(this.name) + 'Model' + ') {',
     '    \'use strict\';',
     '',
@@ -41,7 +41,7 @@ Generator.prototype.createControllerFiles = function createControllerFiles() {
     '    });',
     '',
     '    return ' + this._.classify(this.name) + 'Collection;',
-    '});',
+    '});'
   ].join('\n');
 
   this.write(destFile, template);

--- a/model/index.js
+++ b/model/index.js
@@ -32,12 +32,12 @@ function Generator() {
 util.inherits(Generator, scriptBase);
 
 Generator.prototype.createModelFiles = function createModelFiles() {
-  var ext = this.options.coffee ? 'coffee' : 'js';
-  var destFile = path.join('app/scripts/models', this.name + '-model.' + ext);
+  var ext = this.options.coffee ? '.coffee' : '.js';
+  var destFile = path.join('app/scripts/models', this.name + ext);
   this.isRequireJsApp = this.isUsingRequireJS();
 
   if (!this.isRequireJsApp) {
-    this.template('model.' + ext, destFile);
+    this.template('model' + ext, destFile);
     return;
   }
 
@@ -56,7 +56,7 @@ Generator.prototype.createModelFiles = function createModelFiles() {
     '    });',
     '',
     '    return ' + this._.classify(this.name) + 'Model;',
-    '});',
+    '});'
   ].join('\n');
 
   this.write(destFile, template);

--- a/router/index.js
+++ b/router/index.js
@@ -17,12 +17,12 @@ function Generator() {
 util.inherits(Generator, scriptBase);
 
 Generator.prototype.createControllerFiles = function createControllerFiles() {
-  var ext = this.options.coffee ? 'coffee' : 'js';
-  var destFile = path.join('app/scripts/routes', this.name + '-router.' + ext);
+  var ext = this.options.coffee ? '.coffee' : '.js';
+  var destFile = path.join('app/scripts/routes', this.name + ext);
   this.isRequireJsApp = this.isUsingRequireJS();
 
   if (!this.isRequireJsApp) {
-    this.template('router.' + ext, destFile);
+    this.template('router' + ext, destFile);
     return;
   }
 

--- a/test/test-foo.js
+++ b/test/test-foo.js
@@ -101,7 +101,7 @@ describe('Backbone generator test', function () {
       this.backbone.app.run({}, function () {
         model.run([], function () {
           helpers.assertFiles([
-            ['app/scripts/models/foo-model.js',
+            ['app/scripts/models/foo.js',
               /Models.FooModel = Backbone.Model.extend\(\{/]
           ]);
         });
@@ -117,7 +117,7 @@ describe('Backbone generator test', function () {
       this.backbone.app.run({}, function () {
         collection.run([], function () {
           helpers.assertFiles([
-            ['app/scripts/collections/foo-collection.js', /Collections.FooCollection = Backbone.Collection.extend\(\{/]
+            ['app/scripts/collections/foo.js', /Collections.FooCollection = Backbone.Collection.extend\(\{/]
           ]);
         });
         done();
@@ -132,7 +132,7 @@ describe('Backbone generator test', function () {
       this.backbone.app.run({}, function () {
         router.run([], function () {
           helpers.assertFiles([
-            ['app/scripts/routes/foo-router.js', /Routers.FooRouter = Backbone.Router.extend\(\{/]
+            ['app/scripts/routes/foo.js', /Routers.FooRouter = Backbone.Router.extend\(\{/]
           ]);
         });
         done();
@@ -147,7 +147,7 @@ describe('Backbone generator test', function () {
       this.backbone.app.run({}, function () {
         view.run([], function () {
           helpers.assertFiles([
-            ['app/scripts/views/foo-view.js', /Views.FooView = Backbone.View.extend\(\{(.|\n)*app\/scripts\/templates\/foo.ejs/],
+            ['app/scripts/views/foo.js', /Views.FooView = Backbone.View.extend\(\{(.|\n)*app\/scripts\/templates\/foo.ejs/],
             'app/scripts/templates/foo.ejs'
           ]);
         });

--- a/test/test-requirejs.js
+++ b/test/test-requirejs.js
@@ -74,7 +74,7 @@ describe('Backbone generator with RequireJS', function () {
         '.jshintrc',
         '.editorconfig',
         'Gruntfile.js',
-        'package.json',
+        'package.json'
       ];
 
       this.backbone.app.run({}, function () {
@@ -91,7 +91,7 @@ describe('Backbone generator with RequireJS', function () {
       this.backbone.app.run({}, function () {
         model.run([], function () {
           helpers.assertFiles([
-            ['app/scripts/models/foo-model.js', /var FooModel = Backbone.Model.extend\(\{/]
+            ['app/scripts/models/foo.js', /var FooModel = Backbone.Model.extend\(\{/]
           ]);
         });
 
@@ -107,7 +107,7 @@ describe('Backbone generator with RequireJS', function () {
       this.backbone.app.run({}, function () {
         collection.run([], function () {
           helpers.assertFiles([
-            ['app/scripts/collections/foo-collection.js', /var FooCollection = Backbone.Collection.extend\(\{/]
+            ['app/scripts/collections/foo.js', /var FooCollection = Backbone.Collection.extend\(\{/]
           ]);
         });
 
@@ -123,7 +123,7 @@ describe('Backbone generator with RequireJS', function () {
       this.backbone.app.run({}, function () {
         router.run([], function () {
           helpers.assertFiles([
-            ['app/scripts/routes/foo-router.js', /var FooRouter = Backbone.Router.extend\(\{/]
+            ['app/scripts/routes/foo.js', /var FooRouter = Backbone.Router.extend\(\{/]
           ]);
         });
 
@@ -139,7 +139,7 @@ describe('Backbone generator with RequireJS', function () {
       this.backbone.app.run({}, function () {
         view.run([], function () {
           helpers.assertFiles([
-            ['app/scripts/views/foo-view.js', /var FooView = Backbone.View.extend\(\{(.|\n)*app\/scripts\/templates\/foo.ejs/],
+            ['app/scripts/views/foo.js', /var FooView = Backbone.View.extend\(\{(.|\n)*app\/scripts\/templates\/foo.ejs/],
             'app/scripts/templates/foo.ejs'
           ]);
         });

--- a/view/index.js
+++ b/view/index.js
@@ -16,7 +16,7 @@ function Generator() {
 util.inherits(Generator, scriptBase);
 
 Generator.prototype.createViewFiles = function createViewFiles() {
-  var ext = this.options.coffee ? 'coffee' : 'js';
+  var ext = this.options.coffee ? '.coffee' : '.js';
   var templateFramework = this.getTemplateFramework();
   var templateExt = '.ejs';
   if (templateFramework === 'mustache') {
@@ -25,7 +25,7 @@ Generator.prototype.createViewFiles = function createViewFiles() {
     templateExt = '.hbs';
   }
   this.jst_path = 'app/scripts/templates/' + this.name + templateExt;
-  var destFile = path.join('app/scripts/views', this.name + '-view.' + ext);
+  var destFile = path.join('app/scripts/views', this.name + ext);
   var isRequireJsApp = this.isUsingRequireJS();
 
   this.template('view.ejs', this.jst_path);
@@ -33,7 +33,7 @@ Generator.prototype.createViewFiles = function createViewFiles() {
     this.jst_path = this.name + '-template';
   }
   if (!isRequireJsApp) {
-    this.template('view.' + ext, destFile);
+    this.template('view' + ext, destFile);
     return;
   }
 
@@ -53,7 +53,7 @@ Generator.prototype.createViewFiles = function createViewFiles() {
     '    });',
     '',
     '    return ' + this._.classify(this.name) + 'View;',
-    '});',
+    '});'
   ].join('\n');
 
   this.write(destFile, template);


### PR DESCRIPTION
Currently model, collection, route and view generators add a hyphenated suffix to the generated filenames (e.g. `-model.js`, `-collection.js`, `-route.js`, `-view.js`).

I've looked at the Angular generator and I think it does the right thing: instead of adding a suffix to the file name, it just puts it in the correct folder and appends the extension. So I would suggest doing the same: e.g. `models/todo.js`, `collections/todo.js`, `routes/todo.js` and `views/todo.js`
