### PR TITLE
Fix typos in the require statements in app.js/app.coffee

### DIFF
--- a/templates/app.js
+++ b/templates/app.js
@@ -16,7 +16,7 @@ require('.tmp/scripts/templates');
 require('app/scripts/views/*');
 require('app/scripts/models/*');
 require('app/scripts/collections/*');
-require('app/scripts/routers/*');
+require('app/scripts/routes/*');
 
 $(document).ready(function () {
     <%= _.camelize(appname) %>.init();

--- a/templates/coffeescript/app.coffee
+++ b/templates/coffeescript/app.coffee
@@ -10,8 +10,8 @@ window.<%= _.camelize(appname) %> =
 require('.tmp/scripts/templates');
 require('.tmp/scripts/views/*');
 require('.tmp/scripts/models/*');
-require('.tmp/scripts/controllers/*');
-require('.tmp/scripts/routers/*');
+require('.tmp/scripts/collections/*');
+require('.tmp/scripts/routes/*');
 
 $ ->
   <%= _.camelize(appname) %>.init();


### PR DESCRIPTION
Fixed the require statements to match the folders that are created by the generator.
- "routers" -> "routes"
- "controllers" -> "collections"
