### PR TITLE
Added a "grunt testserver" task for inspecting tests in a browser

### DIFF
--- a/app/templates/Gruntfile.js
+++ b/app/templates/Gruntfile.js
@@ -351,6 +351,17 @@ module.exports = function (grunt) {
     grunt.registerTask('server', function (target) {
         if (target === 'dist') {
             return grunt.task.run(['build', 'open', 'connect:dist:keepalive']);
+        } else if (target === 'test') {
+            return grunt.task.run([
+                'clean:server',
+                'coffee',
+                'createDefaultTemplate',<% if (templateFramework === 'mustache' ) { %>
+                'mustache',<% } else if (templateFramework === 'handlebars') { %>
+                'handlebars',<% } else { %>
+                'jst',<% } %>
+                'compass:server',
+                'connect:test:keepalive'
+            ]);
         }
 
         grunt.task.run([
@@ -379,17 +390,6 @@ module.exports = function (grunt) {
         'mocha'<% } else { %>
         'jasmine',
         'watch:test'<% } %>
-    ]);
-
-    grunt.registerTask('testserver', [
-        'clean:server',
-        'coffee',
-        'createDefaultTemplate',<% if (templateFramework === 'mustache' ) { %>
-        'mustache',<% } else if (templateFramework === 'handlebars') { %>
-        'handlebars',<% } else { %>
-        'jst',<% } %>
-        'compass:server',
-        'connect:test:keepalive'
     ]);
 
     grunt.registerTask('build', [


### PR DESCRIPTION
Automated tests in a headless browser are a great, but sometimes I'd rather inspect and debug tests in a "real" browser. Perhaps I am not the only one ... Why not make life a little easier by adding a `grunt testserver` task?

It essentially is the same as `grunt server`, but 
- it sets the docroot to the test directory
- it merges the test and app directories

just like the test task does.

Cheers,

Michael
