### PR TITLE
4 space CoffeeScript indents (formerly 2)

### DIFF
--- a/templates/coffeescript/app.coffee
+++ b/templates/coffeescript/app.coffee
@@ -1,12 +1,12 @@
 window.<%= _.camelize(appname) %> =
-  Models: {}
-  Collections: {}
-  Views: {}
-  Routers: {}
-  init: ->
-    'use strict'
-    console.log 'Hello from Backbone!'
+    Models: {}
+    Collections: {}
+    Views: {}
+    Routers: {}
+    init: ->
+        'use strict'
+        console.log 'Hello from Backbone!'
 
 $ ->
-  'use strict'
-  <%= _.camelize(appname) %>.init();
+    'use strict'
+    <%= _.camelize(appname) %>.init();

--- a/templates/coffeescript/collection.coffee
+++ b/templates/coffeescript/collection.coffee
@@ -1,2 +1,2 @@
 class <%= _.camelize(appname) %>.Collections.<%= _.classify(name) %>Collection extends Backbone.Collection
-  model: <%= _.camelize(appname) %>.Models.<%= _.classify(name) %>Model
+    model: <%= _.camelize(appname) %>.Models.<%= _.classify(name) %>Model


### PR DESCRIPTION
This is one of those patches where I feel like I'm missing something. Basically, I noticed the CS files were only 2-space indented, while the editorconfig (and plain JS files) are generated with 4 spaces. Should we have 4 spaces in both cases?
