### PR TITLE
Adding prompt for CoffeeScript when --coffee is not used

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -45,12 +45,16 @@ Generator.prototype.askFor = function askFor() {
       name: 'Twitter Bootstrap for Sass',
       value: 'compassBootstrap',
       checked: true
-    }, {
-      name: 'RequireJS',
-      value: 'includeRequireJS',
-      checked: true
     }]
   }];
+
+  if (!this.options.coffee) {
+    prompts[0].choices.push({
+      name: 'Use CoffeeScript',
+      value: 'coffee',
+      checked: true
+    });
+  }
 
   this.prompt(prompts, function (answers) {
     var features = answers.features;
@@ -60,9 +64,25 @@ Generator.prototype.askFor = function askFor() {
     // manually deal with the response, get back and store the results.
     // we change a bit this way of doing to automatically do this in the self.prompt() method.
     this.compassBootstrap = hasFeature('compassBootstrap');
-    this.includeRequireJS = hasFeature('includeRequireJS');
 
-    cb();
+    if (!this.options.coffee) {
+      this.options.coffee   = hasFeature('coffee');
+    }
+
+    if (!this.options.coffee) {
+      this.prompt([{
+        type: 'confirm',
+        name: 'includeRequireJS',
+        message: 'Add RequireJS ?'
+      }], function (answers) {
+        this.includeRequireJS = answers.includeRequireJS;
+
+        cb();
+      }.bind(this));
+    } else {
+      this.includeRequireJS = false;
+      cb();
+    }
   }.bind(this));
 };
 

--- a/test/test-foo.js
+++ b/test/test-foo.js
@@ -45,7 +45,8 @@ describe('Backbone generator test', function () {
       this.backbone.app.options['skip-install'] = true;
 
       helpers.mockPrompt(this.backbone.app, {
-        features: ['compassBootstrap']
+        features: ['compassBootstrap'],
+        includeRequireJS: false
       });
 
       done();

--- a/test/test-requirejs.js
+++ b/test/test-requirejs.js
@@ -20,7 +20,8 @@ describe('Backbone generator with RequireJS', function () {
       this.backbone.app.options['skip-install'] = true;
 
       helpers.mockPrompt(this.backbone.app, {
-        features: ['compassBootstrap', 'includeRequireJS']
+        features: ['compassBootstrap'],
+        includeRequireJS: true
       });
 
       done();


### PR DESCRIPTION
- Show CS checkbox only when `--coffee` is not provided
- Since RequireJS + CS not supported right now, RequireJS prompt will show only when coffee option is not selected

cc\ @passy @addyosmani @sindresorhus Can anyone review this?
