### PR TITLE
make 'grunt server:test' watch for app & test changes

### DIFF
--- a/app/templates/Gruntfile.js
+++ b/app/templates/Gruntfile.js
@@ -97,6 +97,7 @@ module.exports = function (grunt) {
                 options: {
                     middleware: function (connect) {
                         return [
+                            lrSnippet,
                             mountFolder(connect, '.tmp'),
                             mountFolder(connect, 'test'),
                             mountFolder(connect, yeomanConfig.app)
@@ -360,7 +361,8 @@ module.exports = function (grunt) {
                 'handlebars',<% } else { %>
                 'jst',<% } %>
                 'compass:server',
-                'connect:test:keepalive'
+                'connect:test:keepalive',
+                'watch'
             ]);
         }
 

--- a/app/templates/test/index.html
+++ b/app/templates/test/index.html
@@ -8,7 +8,12 @@
 <body>
   <div id="mocha"></div>
   <script src="lib/mocha-1.2.2/mocha.js"></script>
-  <script>mocha.setup('bdd')</script>
+  <script>
+    mocha.setup({
+      ui: 'bdd',
+      globals: [ 'LiveReload' ]
+    });
+  </script>
 
   <!-- assertion framework -->
   


### PR DESCRIPTION
testcases run automatically as you add new ones and/or implement them

as discussed with @hashchange in yeoman/generator-backbone#124
