### PR TITLE
Set a different port to grunt server:test

### DIFF
--- a/app/templates/Gruntfile.js
+++ b/app/templates/Gruntfile.js
@@ -95,6 +95,7 @@ module.exports = function (grunt) {
             },
             test: {
                 options: {
+                    port: 9001,
                     middleware: function (connect) {
                         return [
                             mountFolder(connect, '.tmp'),


### PR DESCRIPTION
This allows to have the application and the testing framework running together.
