### PR TITLE
Fix Gruntfile.js mocha task to use correct port

### DIFF
--- a/app/templates/Gruntfile.js
+++ b/app/templates/Gruntfile.js
@@ -140,7 +140,7 @@ module.exports = function (grunt) {
             all: {
                 options: {
                     run: true,
-                    urls: ['http://localhost:<%%= connect.options.port %>/index.html']
+                    urls: ['http://localhost:<%%= connect.test.options.port %>/index.html']
                 }
             }
         }<% } else { %>,


### PR DESCRIPTION
phantomjs from `grunt server` task should connect to the port configured in `connect.test.port`
