### PR TITLE
Added 'use strict' to app/index.js, to match documentation

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -1,3 +1,4 @@
+'use strict';
 var util = require('util');
 var path = require('path');
 var yeoman = require('yeoman-generator');


### PR DESCRIPTION
Also to match sibling generators, like `angular` and `webapp`.

Should resolve #58.
