### PR TITLE
Skip compass task in Gruntfile when user opt-out bootstrap

### DIFF
--- a/app/templates/Gruntfile.js
+++ b/app/templates/Gruntfile.js
@@ -39,11 +39,11 @@ module.exports = function (grunt) {
             coffeeTest: {
                 files: ['test/spec/{,*/}*.coffee'],
                 tasks: ['coffee:test']
-            },
+            },<% if (compassBootstrap) { %>
             compass: {
                 files: ['<%%= yeoman.app %>/styles/{,*/}*.{scss,sass}'],
                 tasks: ['compass']
-            },
+            },<% } %>
             livereload: {
                 options: {
                     livereload: LIVERELOAD_PORT
@@ -185,7 +185,7 @@ module.exports = function (grunt) {
                     ext: '.js'
                 }]
             }
-        },
+        },<% if (compassBootstrap) { %>
         compass: {
             options: {
                 sassDir: '<%%= yeoman.app %>/styles',
@@ -202,7 +202,7 @@ module.exports = function (grunt) {
                     debugInfo: true
                 }
             }
-        },<% if (includeRequireJS) { %>
+        },<% } %><% if (includeRequireJS) { %>
         requirejs: {
             dist: {
                 // Options: https://github.com/jrburke/r.js/blob/master/build/example.build.js
@@ -296,8 +296,8 @@ module.exports = function (grunt) {
                         '*.{ico,txt}',
                         '.htaccess',
                         'images/{,*/}*.{webp,gif}',
-                        'styles/fonts/{,*/}*.*',
-                        'bower_components/sass-bootstrap/fonts/*.*'
+                        'styles/fonts/{,*/}*.*',<% if (compassBootstrap) { %>
+                        'bower_components/sass-bootstrap/fonts/*.*'<% } %>
                     ]
                 }]
             }
@@ -347,7 +347,8 @@ module.exports = function (grunt) {
                         '<%%= yeoman.dist %>/scripts/{,*/}*.js',
                         '<%%= yeoman.dist %>/styles/{,*/}*.css',
                         '<%%= yeoman.dist %>/images/{,*/}*.{png,jpg,jpeg,gif,webp}',
-                        '<%= yeoman.dist %>/styles/fonts/{,*/}*.*'
+                        '<%= yeoman.dist %>/styles/fonts/{,*/}*.*',<% if (compassBootstrap) { %>
+                        'bower_components/sass-bootstrap/fonts/*.*'<% } %>
                     ]
                 }
             }
@@ -370,8 +371,8 @@ module.exports = function (grunt) {
                 'createDefaultTemplate',<% if (templateFramework === 'mustache' ) { %>
                 'mustache',<% } else if (templateFramework === 'handlebars') { %>
                 'handlebars',<% } else { %>
-                'jst',<% } %>
-                'compass:server',
+                'jst',<% } %><% if (compassBootstrap) { %>
+                'compass:server',<% } %>
                 'connect:test',
                 'watch:livereload'
             ]);
@@ -383,8 +384,8 @@ module.exports = function (grunt) {
             'createDefaultTemplate',<% if (templateFramework === 'mustache') { %>
             'mustache',<% } else if (templateFramework === 'handlebars') { %>
             'handlebars',<% } else { %>
-            'jst',<% } %>
-            'compass:server',
+            'jst',<% } %><% if (compassBootstrap) { %>
+            'compass:server',<% } %>
             'connect:livereload',
             'open',
             'watch'
@@ -397,8 +398,8 @@ module.exports = function (grunt) {
         'createDefaultTemplate',<% if (templateFramework === 'mustache' ) { %>
         'mustache',<% } else if (templateFramework === 'handlebars') { %>
         'handlebars',<% } else { %>
-        'jst',<% } %>
-        'compass',<% if(testFramework === 'mocha') { %>
+        'jst',<% } %><% if (compassBootstrap) { %>
+        'compass',<% } %><% if(testFramework === 'mocha') { %>
         'connect:test',
         'mocha',<% } else { %>
         'jasmine',<% } %>
@@ -411,8 +412,8 @@ module.exports = function (grunt) {
         'createDefaultTemplate',<% if (templateFramework === 'mustache' ) { %>
         'mustache',<% } else if (templateFramework === 'handlebars') { %>
         'handlebars',<% } else { %>
-        'jst',<% } %>
-        'compass:dist',
+        'jst',<% } %><% if (compassBootstrap) { %>
+        'compass:dist',<% } %>
         'useminPrepare',<% if (includeRequireJS) { %>
         'requirejs',<% } %>
         'imagemin',

--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -10,8 +10,8 @@
     "grunt-mustache": "~0.1.4",<% } else if (templateFramework === 'handlebars') { %>
     "grunt-contrib-handlebars": "~0.5.8",<% } else { %>
     "grunt-contrib-jst": "~0.5.0",<% } %>
-    "grunt-contrib-uglify": "~0.2.0",
-    "grunt-contrib-compass": "~0.5.0",
+    "grunt-contrib-uglify": "~0.2.0",<% if (compassBootstrap) { %>
+    "grunt-contrib-compass": "~0.5.0",<% } %>
     "grunt-contrib-jshint": "~0.6.3",
     "grunt-contrib-cssmin": "~0.6.0",
     "grunt-contrib-connect": "~0.3.0",


### PR DESCRIPTION
Remove the `grunt-contrib-compass` from package.json and `compass` related tasks from Gruntfile when user uncheck compass bootstrap in prompts 
