### PR TITLE
Livereload support for CoffeeScript

### DIFF
--- a/app/templates/Gruntfile.js
+++ b/app/templates/Gruntfile.js
@@ -52,7 +52,7 @@ module.exports = function (grunt) {
                     '<%%= yeoman.app %>/*.html',
                     '{.tmp,<%%= yeoman.app %>}/styles/{,*/}*.css',
                     '{.tmp,<%%= yeoman.app %>}/scripts/{,*/}*.js',
-                    '{.tmp,<%%= yeoman.app %>}/scripts/{,*/}*.coffee',
+                    '<%%= yeoman.app %>/scripts/{,*/}*.coffee',
                     '<%%= yeoman.app %>/images/{,*/}*.{png,jpg,jpeg,gif,webp}',
                     '<%%= yeoman.app %>/scripts/templates/*.{ejs,mustache,hbs}',
                     'test/spec/**/*.js'


### PR DESCRIPTION
This change updates CoffeeScript's change listeners to listen to the save event instead of just the compile event, and fixes LiveReload in Ubuntu.

Template currently are listening for both the save & compile events too, and seem to be working well.

```
'{.tmp,<%%= yeoman.app %>}/scripts/{,*/}*.js'
// and
'<%%= yeoman.app %>/scripts/templates/*.{ejs,mustache,hbs}',
```
