### PR TITLE
Implementing --appPath option to scaffold into custom directory

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -8,12 +8,8 @@ var scriptBase = require('../script-base');
 var Generator = module.exports = function Generator(args, options, config) {
   yeoman.generators.Base.apply(this, arguments);
 
-  if (typeof this.env.options.appPath === 'undefined') {
-    try {
-      this.env.options.appPath = require(path.join(process.cwd(), 'bower.json')).appPath;
-    } catch (e) {}
-    this.env.options.appPath = this.env.options.appPath || 'app';
-  }
+  this.env.options.appPath = this.options.appPath || 'app';
+  this.config.set('appPath', this.env.options.appPath);
 
   this.testFramework = this.options['test-framework'] || 'mocha';
   this.templateFramework = this.options['template-framework'] || 'lodash';
@@ -91,12 +87,12 @@ Generator.prototype.askFor = function askFor() {
 };
 
 Generator.prototype.git = function git() {
-  this.copy('gitignore', '.gitignore');
+  this.template('gitignore', '.gitignore');
   this.copy('gitattributes', '.gitattributes');
 };
 
 Generator.prototype.bower = function bower() {
-  this.copy('bowerrc', '.bowerrc');
+  this.template('bowerrc', '.bowerrc');
   this.copy('_bower.json', 'bower.json');
 };
 
@@ -123,9 +119,9 @@ Generator.prototype.mainStylesheet = function mainStylesheet() {
   ];
   var ext = '.css';
   if (this.compassBootstrap) {
-    this.template('main.scss', 'app/styles/main.scss');
+    this.template('main.scss', this.env.options.appPath + '/styles/main.scss');
   }
-  this.write('app/styles/main' + ext, contentText.join('\n'));
+  this.write(this.env.options.appPath + '/styles/main' + ext, contentText.join('\n'));
 };
 
 Generator.prototype.writeIndex = function writeIndex() {
@@ -169,7 +165,7 @@ Generator.prototype.writeIndex = function writeIndex() {
   this.indexFile = this.appendFiles({
     html: this.indexFile,
     fileType: 'js',
-    searchPath: ['.tmp', 'app'],
+    searchPath: ['.tmp', this.env.options.appPath],
     optimizedPath: 'scripts/main.js',
     sourceFileList: [
       'scripts/main.js',
@@ -191,28 +187,28 @@ Generator.prototype.writeIndexWithRequirejs = function writeIndexWithRequirejs()
 };
 
 Generator.prototype.setupEnv = function setupEnv() {
-  this.mkdir('app');
-  this.mkdir('app/scripts');
-  this.mkdir('app/scripts/vendor/');
-  this.mkdir('app/styles');
-  this.mkdir('app/images');
-  this.template('app/404.html');
-  this.template('app/favicon.ico');
-  this.template('app/robots.txt');
-  this.copy('app/htaccess', 'app/.htaccess');
-  this.write('app/index.html', this.indexFile);
+  this.mkdir(this.env.options.appPath);
+  this.mkdir(this.env.options.appPath + '/scripts');
+  this.mkdir(this.env.options.appPath + '/scripts/vendor/');
+  this.mkdir(this.env.options.appPath + '/styles');
+  this.mkdir(this.env.options.appPath + '/images');
+  this.copy('app/404.html', this.env.options.appPath + '/404.html');
+  this.copy('app/favicon.ico', this.env.options.appPath + '/favicon.ico');
+  this.copy('app/robots.txt', this.env.options.appPath + '/robots.txt');
+  this.copy('app/htaccess', this.env.options.appPath + '/.htaccess');
+  this.write(this.env.options.appPath + '/index.html', this.indexFile);
 };
 
 Generator.prototype.mainJs = function mainJs() {
   if (!this.includeRequireJS) {
     return;
   }
-  this.writeTemplate('main', 'app/scripts/main');
+  this.writeTemplate('main', this.env.options.appPath + '/scripts/main');
 };
 
 Generator.prototype.createAppFile = function createAppFile() {
   if (this.includeRequireJS) {
     return;
   }
-  this.writeTemplate('app', 'app/scripts/main');
+  this.writeTemplate('app', this.env.options.appPath + '/scripts/main');
 };

--- a/app/templates/Gruntfile.js
+++ b/app/templates/Gruntfile.js
@@ -21,7 +21,7 @@ module.exports = function (grunt) {
 
     // configurable paths
     var yeomanConfig = {
-        app: 'app',
+        app: '<%= env.options.appPath %>',
         dist: 'dist'
     };
 

--- a/app/templates/bowerrc
+++ b/app/templates/bowerrc
@@ -1,3 +1,3 @@
 {
-    "directory": "app/bower_components"
+    "directory": "<%= env.options.appPath %>/bower_components"
 }

--- a/app/templates/gitignore
+++ b/app/templates/gitignore
@@ -2,6 +2,6 @@ node_modules
 dist
 test/temp
 .sass-cache
-app/bower_components
+<%= env.options.appPath %>/bower_components
 .tmp
 test/bower_components/

--- a/collection/index.js
+++ b/collection/index.js
@@ -17,7 +17,7 @@ function Generator() {
 util.inherits(Generator, scriptBase);
 
 Generator.prototype.createControllerFiles = function createControllerFiles() {
-  this.writeTemplate('collection', path.join('app/scripts/collections', this.name));
+  this.writeTemplate('collection', path.join(this.env.options.appPath + '/scripts/collections', this.name));
 
   if (!this.options.requirejs) {
     this.addScriptToIndex('collections/' + this.name);

--- a/model/index.js
+++ b/model/index.js
@@ -30,7 +30,7 @@ function Generator() {
 util.inherits(Generator, scriptBase);
 
 Generator.prototype.createModelFiles = function createModelFiles() {
-  this.writeTemplate('model', path.join('app/scripts/models', this.name));
+  this.writeTemplate('model', path.join(this.env.options.appPath + '/scripts/models', this.name));
 
   if (!this.options.requirejs) {
     this.addScriptToIndex('models/' + this.name);

--- a/readme.md
+++ b/readme.md
@@ -47,6 +47,10 @@ Also checkout this [NetTuts write-up](http://net.tutsplus.com/tutorials/javascri
 
 ## Options
 
+* `--appPath`
+
+  Generate scaffold into a custom directory.
+
 * `--coffee`
 
   Generate scaffolds in CoffeeScript. By default check if project uses CoffeeScript.

--- a/router/index.js
+++ b/router/index.js
@@ -17,7 +17,7 @@ function Generator() {
 util.inherits(Generator, scriptBase);
 
 Generator.prototype.createControllerFiles = function createControllerFiles() {
-  this.writeTemplate('router', path.join('app/scripts/routes', this.name));
+  this.writeTemplate('router', path.join(this.env.options.appPath + '/scripts/routes', this.name));
 
   if (!this.options.requirejs) {
     this.addScriptToIndex('routes/' + this.name);

--- a/script-base.js
+++ b/script-base.js
@@ -7,12 +7,7 @@ var backboneUtils = require('./util.js');
 var Generator = module.exports = function Generator() {
   yeoman.generators.NamedBase.apply(this, arguments);
 
-  if (typeof this.env.options.appPath === 'undefined') {
-    try {
-      this.env.options.appPath = require(path.join(process.cwd(), 'bower.json')).appPath;
-    } catch (err) {}
-    this.env.options.appPath = this.env.options.appPath || 'app';
-  }
+  this.env.options.appPath = this.config.get('appPath') || 'app';
 
   if (this.env.options.minsafe) {
     sourceRoot += '-min';

--- a/test/test-apppath.js
+++ b/test/test-apppath.js
@@ -1,0 +1,125 @@
+/* global describe, beforeEach, it */
+'use strict';
+var path = require('path');
+var helpers = require('yeoman-generator').test;
+var fs = require('fs');
+
+describe('backbone generator with appPath option', function () {
+  beforeEach(function (done) {
+    helpers.testDirectory(path.join(__dirname, 'temp'), function (err) {
+      if (err) {
+        return done(err);
+      }
+
+      this.app = helpers.createGenerator('backbone:app', [
+        '../../app', [
+          helpers.createDummyGenerator(), 'mocha:app'
+        ]
+      ], ['temp'], {appPath: 'public', 'skip-install': true});
+
+      helpers.mockPrompt(this.app, {
+        features: ['compassBootstrap']
+      });
+
+      var out = [
+        '{',
+        '  "generator-backbone": {',
+        '    "appPath": "public"',
+        '  }',
+        '}'
+      ];
+      fs.writeFileSync('.yo-rc.json', out.join('\n'));
+
+      done();
+    }.bind(this));
+  });
+
+  describe('create expected files', function () {
+    it('in path specified by --appPath', function (done) {
+      var expected = [
+        // add files you expect to exist here.
+        ['Gruntfile.js', /app: 'public'/],
+        ['bower.json', /"name": "temp"/],
+        ['package.json', /"name": "temp"/],
+        'public/404.html',
+        'public/favicon.ico',
+        'public/robots.txt',
+        'public/index.html',
+        'public/.htaccess',
+        '.gitignore',
+        '.gitattributes',
+        '.bowerrc',
+        '.jshintrc',
+        '.editorconfig',
+        'Gruntfile.js',
+        'package.json',
+        'public/scripts/main.js',
+        'public/styles/main.scss'
+      ];
+
+      this.app.run({}, function () {
+        helpers.assertFiles(expected);
+        done();
+      });
+    });
+  });
+
+  describe('creates sub generators', function () {
+
+    it('backbone model', function (done) {
+      var model = helpers.createGenerator('backbone:model', ['../../model'], ['foo']);
+
+      this.app.run({}, function () {
+        model.run([], function () {
+          helpers.assertFiles([
+            ['public/scripts/models/foo.js',
+              /Models.FooModel = Backbone.Model.extend\(\{/]
+          ]);
+        });
+        done();
+      });
+    });
+
+    it('backbone router', function (done) {
+      var router = helpers.createGenerator('backbone:router', ['../../router'], ['foo']);
+
+      this.app.run({}, function () {
+        router.run([], function () {
+          helpers.assertFiles([
+            ['public/scripts/routes/foo.js', /Routers.FooRouter = Backbone.Router.extend\(\{/]
+          ]);
+        });
+        done();
+      });
+    });
+
+    it('backbone collection', function (done) {
+      var collection = helpers.createGenerator('backbone:collection', ['../../collection'], ['foo']);
+
+      this.app.run({}, function () {
+        collection.run([], function () {
+          helpers.assertFiles([
+            ['public/scripts/collections/foo.js', /Collections.FooCollection = Backbone.Collection.extend\(\{/]
+          ]);
+        });
+        done();
+      });
+    });
+
+    it('backbone view', function (done) {
+      var view = helpers.createGenerator('backbone:view', [
+        '../../view'
+      ], ['foo']);
+
+      this.app.run({}, function () {
+        view.run([], function () {
+          helpers.assertFiles([
+            ['public/scripts/views/foo.js', /Views.FooView = Backbone.View.extend\(\{(.|\n)*public\/scripts\/templates\/foo.ejs/],
+            'public/scripts/templates/foo.ejs'
+          ]);
+        });
+        done();
+      });
+    });
+  });
+});

--- a/test/test-coffee-requirejs.js
+++ b/test/test-coffee-requirejs.js
@@ -3,6 +3,7 @@
 var path    = require('path');
 var helpers = require('yeoman-generator').test;
 var assert  = require('assert');
+var fs      = require('fs');
 
 describe('Backbone generator test with --coffee and --requirejs option', function () {
   beforeEach(function (done) {
@@ -25,6 +26,15 @@ describe('Backbone generator test with --coffee and --requirejs option', functio
       helpers.mockPrompt(this.backbone.app, {
         features: ['compassBootstrap', 'coffee', 'requirejs']
       });
+
+      var out = [
+        '{',
+        '  "generator-backbone": {',
+        '    "appPath": "app"',
+        '  }',
+        '}'
+      ];
+      fs.writeFileSync('.yo-rc.json', out.join('\n'));
 
       done();
     }.bind(this));

--- a/test/test-coffee.js
+++ b/test/test-coffee.js
@@ -3,6 +3,7 @@
 var path    = require('path');
 var helpers = require('yeoman-generator').test;
 var assert  = require('assert');
+var fs      = require('fs');
 
 describe('Backbone generator test with --coffee option', function () {
   beforeEach(function (done) {
@@ -22,6 +23,15 @@ describe('Backbone generator test with --coffee option', function () {
       helpers.mockPrompt(this.backbone.app, {
         features: ['compassBootstrap', 'coffee']
       });
+
+      var out = [
+        '{',
+        '  "generator-backbone": {',
+        '    "appPath": "app"',
+        '  }',
+        '}'
+      ];
+      fs.writeFileSync('.yo-rc.json', out.join('\n'));
 
       done();
     }.bind(this));

--- a/test/test-foo.js
+++ b/test/test-foo.js
@@ -3,7 +3,7 @@
 var path    = require('path');
 var helpers = require('yeoman-generator').test;
 var assert  = require('assert');
-
+var fs      = require('fs');
 
 // XXX With current API, (prior v2), that's a complete mess to setup generators
 // if they differ from the standard lib/generators layout.
@@ -47,6 +47,15 @@ describe('Backbone generator test', function () {
       helpers.mockPrompt(this.backbone.app, {
         features: ['compassBootstrap']
       });
+
+      var out = [
+        '{',
+        '  "generator-backbone": {',
+        '    "appPath": "app"',
+        '  }',
+        '}'
+      ];
+      fs.writeFileSync('.yo-rc.json', out.join('\n'));
 
       done();
     }.bind(this));

--- a/test/test-handlebars.js
+++ b/test/test-handlebars.js
@@ -3,6 +3,7 @@
 var path    = require('path');
 var helpers = require('yeoman-generator').test;
 var assert  = require('assert');
+var fs      = require('fs');
 
 describe('Backbone generator with handlebars', function () {
   beforeEach(function (done) {
@@ -23,6 +24,15 @@ describe('Backbone generator with handlebars', function () {
         features: ['compassBootstrap'],
         includeRequireJS: false
       });
+
+      var out = [
+        '{',
+        '  "generator-backbone": {',
+        '    "appPath": "app"',
+        '  }',
+        '}'
+      ];
+      fs.writeFileSync('.yo-rc.json', out.join('\n'));
 
       done();
     }.bind(this));

--- a/test/test-mustache.js
+++ b/test/test-mustache.js
@@ -3,6 +3,7 @@
 var path    = require('path');
 var helpers = require('yeoman-generator').test;
 var assert  = require('assert');
+var fs      = require('fs');
 
 describe('Backbone generator with handlebars', function () {
   beforeEach(function (done) {
@@ -23,6 +24,15 @@ describe('Backbone generator with handlebars', function () {
         features: ['compassBootstrap'],
         includeRequireJS: false
       });
+
+      var out = [
+        '{',
+        '  "generator-backbone": {',
+        '    "appPath": "app"',
+        '  }',
+        '}'
+      ];
+      fs.writeFileSync('.yo-rc.json', out.join('\n'));
 
       done();
     }.bind(this));

--- a/test/test-requirejs.js
+++ b/test/test-requirejs.js
@@ -3,6 +3,7 @@
 var path    = require('path');
 var helpers = require('yeoman-generator').test;
 var assert  = require('assert');
+var fs      = require('fs');
 
 describe('Backbone generator with RequireJS', function () {
   beforeEach(function (done) {
@@ -22,6 +23,15 @@ describe('Backbone generator with RequireJS', function () {
       helpers.mockPrompt(this.backbone.app, {
         features: ['compassBootstrap', 'requirejs']
       });
+
+      var out = [
+        '{',
+        '  "generator-backbone": {',
+        '    "appPath": "app"',
+        '  }',
+        '}'
+      ];
+      fs.writeFileSync('.yo-rc.json', out.join('\n'));
 
       done();
     }.bind(this));

--- a/view/index.js
+++ b/view/index.js
@@ -23,14 +23,14 @@ Generator.prototype.createViewFiles = function createViewFiles() {
   } else if (templateFramework === 'handlebars') {
     templateExt = '.hbs';
   }
-  this.jst_path = 'app/scripts/templates/' + this.name + templateExt;
+  this.jst_path = this.env.options.appPath + '/scripts/templates/' + this.name + templateExt;
 
   this.template('view.ejs', this.jst_path);
   if (templateFramework === 'mustache') {
     this.jst_path = this.name + '-template';
   }
 
-  this.writeTemplate('view', path.join('app/scripts/views', this.name));
+  this.writeTemplate('view', path.join(this.env.options.appPath + '/scripts/views', this.name));
 
   if (!this.options.requirejs) {
     this.addScriptToIndex('views/' + this.name);


### PR DESCRIPTION
Helps user to scaffold application into custom directory instead of "app"

`yo backbone --appPath=public`

This will scaffold application into public directory.
**This uses `.yo-rc.json` for storing appPath config.** 
https://twitter.com/jayjog/status/399971817646874624
