### PR TITLE
bug fix: grunt test command starts watch:test task that fails because it ...

### DIFF
--- a/app/templates/Gruntfile.js
+++ b/app/templates/Gruntfile.js
@@ -415,7 +415,7 @@ module.exports = function (grunt) {
         if(!isConnected) {
             return grunt.task.run(testTasks);
         } else {
-            // already connected, remove the connect:test task
+            // already connected so not going to connect again, remove the connect:test task
             testTasks.splice(testTasks.indexOf('connect:test'), 1);
             return grunt.task.run(testTasks);
         }


### PR DESCRIPTION
...tries to reconnect. Stopped reconnection attempt.

This is simple bug fix for the `grunt test` command. The bug can be easily replicated in a newly generated project by running a test more than once after using the `grunt test` command. When using it I noticed it only works the first time. If I change the test after running `grunt test` it automatically tries to run it again and I get "Fatal error: Port 9001 is already in use by another process.":

```
path>grunt test
Running "clean:server" (clean) task
Cleaning .tmp...OK

Running "coffee:dist" (coffee) task
File .tmp/scripts/main.js created.

Running "coffee:test" (coffee) task

Running "createDefaultTemplate" task

Running "jst:compile" (jst) task
>> Destination not written because compiled files were empty.

Running "compass:dist" (compass) task
directory .tmp/styles/
   create .tmp/styles/main.css (1.261s)
Compilation took 1.307s

Running "compass:server" (compass) task
unchanged app/styles/main.scss
Compilation took 0.121s

Running "connect:test" (connect) task
Started connect web server on localhost:9001.

Running "mocha:all" (mocha) task
Testing: http://localhost:9001/index.html

  .

  1 passing (5ms)

>> 1 passed! (0.01s)

Running "watch:test" (watch) task
Waiting...OK
>> File "test\spec\test.js" changed.


Running "clean:server" (clean) task
Cleaning .tmp...OK

Running "coffee:dist" (coffee) task
File .tmp/scripts/main.js created.

Running "coffee:test" (coffee) task

Running "createDefaultTemplate" task

Running "jst:compile" (jst) task
>> Destination not written because compiled files were empty.

Running "compass:dist" (compass) task
directory .tmp/styles/
   create .tmp/styles/main.css (1.126s)
Compilation took 1.17s

Running "compass:server" (compass) task
unchanged app/styles/main.scss
Compilation took 0.122s

Running "connect:test" (connect) task
Fatal error: Port 9001 is already in use by another process.
```

From what I can tell this happens because when running the `test` task it starts a `watch:test` that calls that `test` task again when test files change. Once it is called the second time, the `test` task stills runs the `connect:test`  task. What I did was simply to add a parameter to the `test` task that indicates whether or not the connection is already established. By omitting the parameter when calling the `test` task it defaults to false. In the `watch:test` the `test:true` task is called setting the isConnected argument to true.

I don’t know if this is the way you would solve the problem, it worked for me, it is simple, so I decided to pull request.

My environment information:

```
yo version: 1.0.4
win32 { http_parser: '1.0',
  node: '0.10.23',
  v8: '3.14.5.9',
  ares: '1.9.0-DEV',
  uv: '0.10.20',
  zlib: '1.2.3',
  modules: '11',
  openssl: '1.0.1e' }
```

Thank you for your time and work!

[![Build Status](https://travis-ci.org/pedrocatre/generator-backbone.png?branch=bug_fix_watch_test)](https://travis-ci.org/pedrocatre/generator-backbone)
