### PR TITLE
fix command grunt server in readme info

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -39,7 +39,7 @@ yo backbone:model blog
 yo backbone:collection blog
 yo backbone:router blog
 yo backbone:view blog
-grunt serve
+grunt server
 ```
 
 Also checkout this [NetTuts write-up](http://net.tutsplus.com/tutorials/javascript-ajax/building-apps-with-the-yeoman-workflow/) for a guide to building Backbone.js apps using this generator.


### PR DESCRIPTION
I found out a command in readme is wrong

```
grunt serve
```

should be

```
grunt server
```

And thanks for all the great works!
