### PR TITLE
Remove now obsolete require.js shims for Backbone, Underscore

### DIFF
--- a/templates/coffeescript/requirejs/main.coffee
+++ b/templates/coffeescript/requirejs/main.coffee
@@ -2,15 +2,7 @@
 'use strict'
 
 require.config
-  shim:
-    underscore:
-      exports: '_'
-    backbone:
-      deps: [
-        'underscore'
-        'jquery'
-      ]
-      exports: 'Backbone'<% if (compassBootstrap) { %>
+  shim: <% if (compassBootstrap) { %>
     bootstrap:
       deps: ['jquery'],
       exports: 'jquery'<% } %><% if (templateFramework === 'handlebars') { %>

--- a/templates/requirejs/main.js
+++ b/templates/requirejs/main.js
@@ -2,17 +2,7 @@
 'use strict';
 
 require.config({
-    shim: {
-        underscore: {
-            exports: '_'
-        },
-        backbone: {
-            deps: [
-                'underscore',
-                'jquery'
-            ],
-            exports: 'Backbone'
-        }<% if (compassBootstrap) { %>,
+    shim: {<% if (compassBootstrap) { %>
         bootstrap: {
             deps: ['jquery'],
             exports: 'jquery'


### PR DESCRIPTION
Fixes #101

Backbone and Underscore are now properly AMDified, so we don't need to define a
shim config for them anymore.
