### PR TITLE
default grunt task never gets to "build" task

### DIFF
--- a/app/templates/Gruntfile.js
+++ b/app/templates/Gruntfile.js
@@ -417,8 +417,7 @@ module.exports = function (grunt) {
                 'compass',<% } %><% if(testFramework === 'mocha') { %>
                 'connect:test',
                 'mocha',<% } else { %>
-                'jasmine',<% } %>
-                'watch:test'
+                'jasmine'<% } %>
             ];
 
         if(!isConnected) {


### PR DESCRIPTION
I believe the `watch:test` task that is part of the default `grunt test` task is a redundancy. If you want this behavior, you can run `grunt serve:test`. The `watch` task in `grunt default` blocks grunt from reaching the `build` process.
