### PR TITLE
Templates not livereloading

### DIFF
--- a/app/templates/Gruntfile.js
+++ b/app/templates/Gruntfile.js
@@ -387,7 +387,7 @@ module.exports = function (grunt) {
                 'compass:server',<% } %>
                 'connect:test',
                 'open:test',
-                'watch:livereload'
+                'watch'
             ]);
         }
 
@@ -401,7 +401,7 @@ module.exports = function (grunt) {
             'compass:server',<% } %>
             'connect:livereload',
             'open:server',
-            'watch:livereload'
+            'watch'
         ]);
     });
 


### PR DESCRIPTION
When updating a template file the `handlebars` task is not being fired by the watcher. This means that livereload refreshes the page however, the template isn't updated.

Changing this task to `watch` so that the `watch:handlebars` is fired and the templates are updated.
