### PR TITLE
Use options.namespace instead of this.generatorName

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -18,7 +18,7 @@ var Generator = module.exports = function Generator(args, options, config) {
   this.testFramework = this.options['test-framework'] || 'mocha';
   this.templateFramework = this.options['template-framework'] || 'lodash';
 
-  if (['app', 'backbone'].indexOf(this.generatorName) >= 0) {
+  if (this.options.namespace === 'backbone:app') {
     this.hookFor(this.testFramework, {
       as: 'app',
       options: {
@@ -41,7 +41,7 @@ var Generator = module.exports = function Generator(args, options, config) {
   this.indexFile = this.readFileAsString(path.join(this.sourceRoot(), 'index.html'));
 
   this.on('end', function () {
-    if (['app', 'backbone'].indexOf(this.generatorName) >= 0) {
+    if (this.options.namespace === 'backbone:app') {
       if (/^.*test$/.test(process.cwd())) {
         process.chdir('..');
       }


### PR DESCRIPTION
In latest yeoman-generator ~0.16.0, this.generatorName is missing.
so instead of `this.generatorName` now using `this.options.namespace`

cc\ @SBoudrias
