### PR TITLE
change appPath to accept bower.json config

### DIFF
--- a/all/index.js
+++ b/all/index.js
@@ -10,7 +10,15 @@ function Generator(args, options, config) {
   this.dirs = 'models collections views routes helpers templates'.split(' ');
 
   this.option('coffee');
-  this.env.options.appPath = this.options.appPath || 'app';
+  
+  if (typeof this.env.options.appPath === 'undefined') {
+    try {
+      this.env.options.appPath = require(path.join(process.cwd(), 'bower.json')).appPath;
+    } catch (e) {}
+    if(!this.env.options.appPath) {
+      this.env.options.appPath = this.options.appPath || 'app';
+    }
+  }
   this.config.set('appPath', this.env.options.appPath);
 
   args = ['application'];

--- a/app/index.js
+++ b/app/index.js
@@ -12,7 +12,14 @@ var Generator = module.exports = function Generator(args, options, config) {
   this.appname = this.appname || path.basename(process.cwd());
   this.appname = backboneUtils.classify(this.appname);
 
-  this.env.options.appPath = this.options.appPath || 'app';
+  if (typeof this.env.options.appPath === 'undefined') {
+    try {
+      this.env.options.appPath = require(path.join(process.cwd(), 'bower.json')).appPath;
+    } catch (e) {}
+    if(!this.env.options.appPath) {
+      this.env.options.appPath = this.options.appPath || 'app';
+    }
+  }
   this.config.set('appPath', this.env.options.appPath);
 
   this.testFramework = this.options['test-framework'] || 'mocha';


### PR DESCRIPTION
Change `appPath` variable to accept bower.json config as well as the
`env` variable and option. The variable accepts values from the
environment variable, the bower config file, the option, and then
defaults to ‘app,’ in that order.
