### PR TITLE
Update script-base.js - Fix Issue #255

### DIFF
--- a/script-base.js
+++ b/script-base.js
@@ -33,7 +33,7 @@ var Generator = module.exports = function Generator() {
     this.option('requirejs');
 
     // Respect 'includeRequireJS'-Option 
-    this.env.options.requirejs  = this.config.get('includeRequireJS') || 'false';
+    this.env.options.requirejs  = this.config.get('includeRequireJS') || this.config.get('requirejs');
     this.options.requirejs = this.env.options.requirejs;
   }
 


### PR DESCRIPTION
Fix of issue #255
- Respect 'includeREquireJS'-Option in yo-rc.json
- Remove wrong and not longer necessary implementation of 'checkIfUsingRequireJS'

Reason:

Existing check did not respect configuration option. It checks if a file at a hardcoded subpath exists or not. This might deliver a result which looks correct as long as the user did not change the default app-path from 'app' to e.g. 'myapp' - but in fact it's not a requirejs detection and it did not respect the 'includeRequireJS'-Option.
