### PR TITLE
Added support for empty shims, with CoffeeScript

### DIFF
--- a/app/templates/requirejs_app.coffee
+++ b/app/templates/requirejs_app.coffee
@@ -2,12 +2,13 @@
 'use strict'
 
 require.config
-  shim: <% if (compassBootstrap) { %>
+  shim: {<% if (compassBootstrap) { %>
     bootstrap:
       deps: ['jquery'],
       exports: 'jquery'<% } %><% if (templateFramework === 'handlebars') { %>
     handlebars:
       exports: 'Handlebars'<% } %>
+  }
   paths:
     jquery: '../bower_components/jquery/dist/jquery'
     backbone: '../bower_components/backbone/backbone'


### PR DESCRIPTION
Currently, if a user chooses CoffeeScript and doesn't choose Compass & Bootstrap, their project won't compile. This can be fixed by wrapping the shim with brackets.
