### PR TITLE
Mustache precompiling with grunt-contrib-hogan

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -169,6 +169,8 @@ var BackboneGenerator = yeoman.generators.Base.extend({
 
       if (this.templateFramework === 'handlebars') {
         vendorJS.push('bower_components/handlebars/handlebars.js');
+      } else if (this.templateFramework === 'mustache') {
+        vendorJS.push('bower_components/hogan/web/builds/2.0.0/hogan-2.0.0.js');
       }
 
       this.indexFile = this.appendScripts(this.indexFile, 'scripts/vendor.js', vendorJS);

--- a/app/templates/Gruntfile.js
+++ b/app/templates/Gruntfile.js
@@ -61,7 +61,7 @@ module.exports = function (grunt) {
                 files: [
                     '<%%= yeoman.app %>/scripts/templates/*.mustache'
                 ],
-                tasks: ['mustache']
+                tasks: ['hogan']
             }<% } else if (templateFramework === 'handlebars') { %>,
             handlebars: {
                 files: [
@@ -314,15 +314,21 @@ module.exports = function (grunt) {
                 rjsConfig: '<%%= yeoman.app %>/scripts/main.js'
             }
         },<% } %><% if (templateFramework === 'mustache') { %>
-        mustache: {
-            files: {
-                src: '<%%= yeoman.app %>/scripts/templates/',
-                dest: '.tmp/scripts/templates.js',
-                options: {<% if (includeRequireJS) { %>
-                    prefix: 'define(function() { this.JST = ',
-                    postfix: '; return this.JST;});'<% } else { %>
-                    prefix: 'this.JST = ',
-                    postfix: ';'<% } %>
+        hogan: {
+            compile: {
+                options: {
+                    //prettify: true,
+                    namespace: 'JST',
+                    defaultName: function(file) {
+                        return require('path').basename(file, '.mustache');
+                    } <% if (includeRequireJS) { %>,
+                    amdWrapper: true,
+                    amdRequire: {
+                        hogan: "Hogan",
+                    } <% } %>
+                },
+                files:{
+                    ".tmp/scripts/templates.js": ["<%%= yeoman.app %>/scripts/templates/*.mustache"]
                 }
             }
         }<% } else if (templateFramework === 'handlebars') { %>
@@ -381,7 +387,7 @@ module.exports = function (grunt) {
                 'clean:server',<% if (options.coffee) { %>
                 'coffee',<% } %>
                 'createDefaultTemplate',<% if (templateFramework === 'mustache' ) { %>
-                'mustache',<% } else if (templateFramework === 'handlebars') { %>
+                'hogan',<% } else if (templateFramework === 'handlebars') { %>
                 'handlebars',<% } else { %>
                 'jst',<% } %><% if (compassBootstrap) { %>
                 'compass:server',<% } %>
@@ -395,7 +401,7 @@ module.exports = function (grunt) {
             'clean:server',<% if (options.coffee) { %>
             'coffee:dist',<% } %>
             'createDefaultTemplate',<% if (templateFramework === 'mustache') { %>
-            'mustache',<% } else if (templateFramework === 'handlebars') { %>
+            'hogan',<% } else if (templateFramework === 'handlebars') { %>
             'handlebars',<% } else { %>
             'jst',<% } %><% if (compassBootstrap) { %>
             'compass:server',<% } %>
@@ -411,7 +417,7 @@ module.exports = function (grunt) {
                 'clean:server',<% if (options.coffee) { %>
                 'coffee',<% } %>
                 'createDefaultTemplate',<% if (templateFramework === 'mustache' ) { %>
-                'mustache',<% } else if (templateFramework === 'handlebars') { %>
+                'hogan',<% } else if (templateFramework === 'handlebars') { %>
                 'handlebars',<% } else { %>
                 'jst',<% } %><% if (compassBootstrap) { %>
                 'compass',<% } %><% if(testFramework === 'mocha') { %>
@@ -433,7 +439,7 @@ module.exports = function (grunt) {
         'clean:dist',<% if (options.coffee) { %>
         'coffee',<% } %>
         'createDefaultTemplate',<% if (templateFramework === 'mustache' ) { %>
-        'mustache',<% } else if (templateFramework === 'handlebars') { %>
+        'hogan',<% } else if (templateFramework === 'handlebars') { %>
         'handlebars',<% } else { %>
         'jst',<% } %><% if (compassBootstrap) { %>
         'compass:dist',<% } %>

--- a/app/templates/_bower.json
+++ b/app/templates/_bower.json
@@ -9,7 +9,8 @@
     "requirejs": "~2.1.10",
     "requirejs-text": "~2.0.10",<% } %>
     "modernizr": "~2.7.1"<% if (templateFramework === 'handlebars') { %>,
-    "handlebars": "~1.3.0"<% } %>
+    "handlebars": "~1.3.0"<% } %><% if (templateFramework === 'mustache') { %>,
+    "hogan": "~3.0.2"<% } %>
   },
   "devDependencies": {}
 }

--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -7,7 +7,7 @@
     "grunt-contrib-copy": "~0.5.0",
     "grunt-contrib-concat": "~0.3.0",<% if (options.coffee) { %>
     "grunt-contrib-coffee": "~0.8.2",<% } %><% if (templateFramework === 'mustache') { %>
-    "grunt-mustache": "~0.1.6",<% } else if (templateFramework === 'handlebars') { %>
+    "grunt-contrib-hogan": "^0.2.4",<% } else if (templateFramework === 'handlebars') { %>
     "grunt-contrib-handlebars": "~0.6.0",<% } else { %>
     "grunt-contrib-jst": "~0.5.1",<% } %>
     "grunt-contrib-uglify": "~0.3.1",<% if (compassBootstrap) { %>

--- a/app/templates/requirejs_app.coffee
+++ b/app/templates/requirejs_app.coffee
@@ -14,7 +14,9 @@ require.config
     backbone: '../bower_components/backbone/backbone'
     underscore: '../bower_components/lodash/dist/lodash'<% if (compassBootstrap) { %>
     bootstrap: '../bower_components/sass-bootstrap/dist/js/bootstrap'<% } %><% if (templateFramework === 'handlebars') { %>
-    handlebars: '../bower_components/handlebars/handlebars'<% } %>
+    handlebars: '../bower_components/handlebars/handlebars'<% } %><% if (templateFramework === 'mustache') { %>
+    hogan: '../bower_components/hogan/web/builds/2.0.0/hogan-2.0.0.amd'<% } %>
+
 
 require [
   'backbone'

--- a/app/templates/requirejs_app.js
+++ b/app/templates/requirejs_app.js
@@ -16,7 +16,8 @@ require.config({
         backbone: '../bower_components/backbone/backbone',
         underscore: '../bower_components/lodash/dist/lodash'<% if (compassBootstrap) { %>,
         bootstrap: '../bower_components/sass-bootstrap/dist/js/bootstrap'<% } %><% if (templateFramework === 'handlebars') { %>,
-        handlebars: '../bower_components/handlebars/handlebars'<% } %>
+        handlebars: '../bower_components/handlebars/handlebars'<% } %><% if (templateFramework === 'mustache') { %>,
+        hogan: '../bower_components/hogan/web/builds/2.0.0/hogan-2.0.0.amd',<% } %>
     }
 });
 

--- a/templates/coffeescript/requirejs/view.coffee
+++ b/templates/coffeescript/requirejs/view.coffee
@@ -19,4 +19,8 @@ define [
         @listenTo @model, 'change', @render
 
     render: () ->
-        @$el.html @template(@model.toJSON())
+    <% if(templateFramework === 'mustache'){ %>
+        @$el.html @template.render(@model.toJSON())  
+    <% } else { %>
+        @$el.html @template(@model.toJSON())   
+    <% } %>

--- a/templates/coffeescript/view.coffee
+++ b/templates/coffeescript/view.coffee
@@ -16,4 +16,9 @@ class <%= _.camelize(appname) %>.Views.<%= _.classify(name) %> extends Backbone.
     @listenTo @model, 'change', @render
 
   render: () ->
-    @$el.html @template(@model.toJSON())
+  	<% if(templateFramework === 'mustache'){ %>
+  	    @$el.html @template.render(@model.toJSON())  
+  	<% } else { %>
+  	    @$el.html @template(@model.toJSON())   
+  	<% } %>
+    

--- a/templates/requirejs/view.js
+++ b/templates/requirejs/view.js
@@ -24,7 +24,11 @@ define([
         },
 
         render: function () {
-            this.$el.html(this.template(this.model.toJSON()));
+        <% if(templateFramework === 'mustache'){ %>
+            this.$el.html(this.template.render(this.model.toJSON()));    
+        <% } else { %>
+            this.$el.html(this.template(this.model.toJSON()));    
+        <% } %>
         }
     });
 

--- a/templates/view.js
+++ b/templates/view.js
@@ -22,9 +22,12 @@
         },
 
         render: function () {
-            this.$el.html(this.template(this.model.toJSON()));
+        <% if(templateFramework === 'mustache'){ %>
+            this.$el.html(this.template.render(this.model.toJSON()));    
+        <% } else { %>
+            this.$el.html(this.template(this.model.toJSON()));    
+        <% } %>
         }
-
     });
 
 })();

--- a/view/index.js
+++ b/view/index.js
@@ -14,17 +14,18 @@ var ViewGenerator = scriptBase.extend({
 
   writing: {
     createViewFiles: function () {
-      var templateFramework =  this.config.get('templateFramework') || 'lodash';
       var templateExt = '.ejs';
-      if (templateFramework === 'mustache') {
+      this.templateFramework =  this.config.get('templateFramework') || 'lodash';
+      
+      if (this.templateFramework === 'mustache') {
         templateExt = '-template.mustache';
-      } else if (templateFramework === 'handlebars') {
+      } else if (this.templateFramework === 'handlebars') {
         templateExt = '.hbs';
       }
       this.jst_path = this.env.options.appPath + '/scripts/templates/' + this.name + templateExt;
 
       this.template('view.ejs', this.jst_path);
-      if (templateFramework === 'mustache') {
+      if (this.templateFramework === 'mustache') {
         this.jst_path = this.name + '-template';
       }
 


### PR DESCRIPTION
grunt-mustache is used only for concatination of templates. I have exchanged grunt-mustache with grunt-contrib-hogan which precompiles templates and also concatinates them into one file.

In this commit I modified
- gruntfile template
- _bower.json
- _package.json
- app/index.js to add hogan as vendor script
- view/index.js to include templateFramework variabe while templating so it's possible to output this.template.render which is hogan's way of rendering precompiled template
- all views to use this.template.render 