### PR TITLE
upgrade to bootstrap sass official

### DIFF
--- a/app/templates/_bower.json
+++ b/app/templates/_bower.json
@@ -2,7 +2,7 @@
   "name": "<%= _.slugify(appname) %>",
   "version": "0.0.0",
   "dependencies": {<% if (compassBootstrap) { %>
-    "sass-bootstrap": "~3.0.2",<% } %>
+    "bootstrap-sass-official": "~3.2.0",<% } %>
     "jquery": "~2.1.0",
     "lodash": "~2.4.1",
     "backbone": "~1.1.0",<% if (includeRequireJS) { %>

--- a/app/templates/main.scss
+++ b/app/templates/main.scss
@@ -1,6 +1,6 @@
-$icon-font-path: "/bower_components/sass-bootstrap/fonts/";
+$icon-font-path: "/bower_components/bootstrap-sass-official/assets/fonts/bootstrap/";
 
-@import 'sass-bootstrap/lib/bootstrap';
+@import 'bootstrap-sass-official/assets/stylesheets/bootstrap.scss';
 
 .browsehappy {
     margin: 0.2em 0;


### PR DESCRIPTION
This resolves issue #269 and upgrades bootstrap to use the official sass version and updates the version to 3.2.0
