### PR TITLE
Fixes custom livereload port option propagation.

### DIFF
--- a/app/templates/Gruntfile.js
+++ b/app/templates/Gruntfile.js
@@ -30,7 +30,7 @@ module.exports = function (grunt) {
         watch: {
             options: {
                 nospawn: true,
-                livereload: true
+                livereload: LIVERELOAD_PORT
             },<% if (options.coffee) { %>
             coffee: {
                 files: ['<%%= yeoman.app %>/scripts/{,*/}*.coffee'],


### PR DESCRIPTION
Using a custom port for livereload does not work.  The `livereload` option for the `watch` task needs a port number, not `true`, in order for the custom port value to be piped along to the `watch` task: https://github.com/gruntjs/grunt-contrib-watch#live-reloading
