### PR TITLE
Fix bootstrap paths

### DIFF
--- a/app/templates/Gruntfile.js
+++ b/app/templates/Gruntfile.js
@@ -303,7 +303,7 @@ module.exports = function (grunt) {
                         '*.{ico,txt}',
                         'images/{,*/}*.{webp,gif}',
                         'styles/fonts/{,*/}*.*',<% if (compassBootstrap) { %>
-                        'bower_components/sass-bootstrap/fonts/*.*'<% } %>
+                        'bower_components/bootstrap-sass-official/assets/fonts/bootstrap/*.*'<% } %>
                     ]
                 }, {
                     src: 'node_modules/apache-server-configs/dist/.htaccess',
@@ -357,7 +357,7 @@ module.exports = function (grunt) {
                         '<%%= yeoman.dist %>/styles/{,*/}*.css',
                         '<%%= yeoman.dist %>/images/{,*/}*.{png,jpg,jpeg,gif,webp}',
                         '<%= yeoman.dist %>/styles/fonts/{,*/}*.*',<% if (compassBootstrap) { %>
-                        'bower_components/sass-bootstrap/fonts/*.*'<% } %>
+                        'bower_components/bootstrap-sass-official/assets/fonts/bootstrap/*.*'<% } %>
                     ]
                 }
             }

--- a/app/templates/requirejs_app.coffee
+++ b/app/templates/requirejs_app.coffee
@@ -13,7 +13,7 @@ require.config
     jquery: '../bower_components/jquery/dist/jquery'
     backbone: '../bower_components/backbone/backbone'
     underscore: '../bower_components/lodash/dist/lodash'<% if (compassBootstrap) { %>
-    bootstrap: '../bower_components/sass-bootstrap/dist/js/bootstrap'<% } %><% if (templateFramework === 'handlebars') { %>
+    bootstrap: '../bower_components/bootstrap-sass-official/assets/javascripts/bootstrap'<% } %><% if (templateFramework === 'handlebars') { %>
     handlebars: '../bower_components/handlebars/handlebars'<% } %>
 
 require [

--- a/app/templates/requirejs_app.js
+++ b/app/templates/requirejs_app.js
@@ -15,7 +15,7 @@ require.config({
         jquery: '../bower_components/jquery/dist/jquery',
         backbone: '../bower_components/backbone/backbone',
         underscore: '../bower_components/lodash/dist/lodash'<% if (compassBootstrap) { %>,
-        bootstrap: '../bower_components/sass-bootstrap/dist/js/bootstrap'<% } %><% if (templateFramework === 'handlebars') { %>,
+        bootstrap: '../bower_components/bootstrap-sass-official/assets/javascripts/bootstrap'<% } %><% if (templateFramework === 'handlebars') { %>,
         handlebars: '../bower_components/handlebars/handlebars'<% } %>
     }
 });


### PR DESCRIPTION
This PR is related to https://github.com/yeoman/generator-backbone/pull/285 and fixes forgotten bootstrap paths which were still pointing to the old `sass-bootstrap`.
