### PR TITLE
Add support for requirejs and Jasmine.

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -243,10 +243,13 @@ var BackboneGenerator = yeoman.generators.Base.extend({
 
     composeTest: function () {
       if (['backbone:app', 'backbone'].indexOf(this.options.namespace) >= 0) {
-        this.composeWith(this.testFramework, {
-          'skip-install': this.options['skip-install'],
-          'ui': this.options.ui,
-          'skipMessage': true,
+        this.composeWith(this.testFramework, { 
+          options: {
+            'skip-install': this.options['skip-install'],
+            'ui': this.options.ui,
+            'skipMessage': true,
+            'requirejs': this.options.requirejs
+          }
         });
       }
     }


### PR DESCRIPTION
The compose function wasn't being called correctly. Pass through the `requirejs` flag
so the testing library can use it.

Work on #276