### PR TITLE
Bump grunt-contrib-imagemin version to 0.9.2

### DIFF
--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -18,7 +18,7 @@
     "grunt-contrib-connect": "^0.8.0",
     "grunt-contrib-clean": "^0.6.0",
     "grunt-contrib-htmlmin": "^0.3.0",
-    "grunt-contrib-imagemin": "^0.8.1",
+    "grunt-contrib-imagemin": "^0.9.2",
     "grunt-contrib-watch": "^0.6.1",<% if (testFramework === 'jasmine') { %>
     "grunt-contrib-jasmine": "^0.8.0",<% }else{ %>
     "grunt-mocha": "^0.4.11",<% } %>


### PR DESCRIPTION
Includes fix for gruntjs/grunt-contrib-imagemin#228 which is affecting me on
Ubuntu 14.10.

Changelog doesn't show any breaking changes and is required to use
the generated project's gruntfile in my case.