### PR TITLE
Fix indentation in `index.html`

### DIFF
--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -77,16 +77,16 @@
         </div>
         <% } else { // sassBootstrap %>
         <div class="hero-unit">
-          <h1>'Allo, 'Allo!</h1>
-          <p>You now have</p>
-          <ul>
-            <li>HTML5 Boilerplate</li>
-            <li>jQuery</li>
-            <li>Backbone.js</li>
-            <li>Lodash.js</li>
-            <li>Modernizr</li>
-            <% if (includeRequireJS) { %><li>RequireJS</li><% } %>
-          </ul>
+            <h1>'Allo, 'Allo!</h1>
+            <p>You now have</p>
+            <ul>
+                <li>HTML5 Boilerplate</li>
+                <li>jQuery</li>
+                <li>Backbone.js</li>
+                <li>Lodash.js</li>
+                <li>Modernizr</li>
+                <% if (includeRequireJS) { %><li>RequireJS</li><% } %>
+            </ul>
         </div>
         <% } // sassBootstrap %>
 


### PR DESCRIPTION
This generator uses [4 spaces](https://github.com/yeoman/generator-backbone/blob/master/app/templates/editorconfig#L11-12) and this seemed to be the only piece of code that uses 2 spaces.