### PR TITLE
Add `Disallow:` to robots.txt

### DIFF
--- a/app/templates/app/robots.txt
+++ b/app/templates/app/robots.txt
@@ -1,3 +1,4 @@
 # robotstxt.org
 
 User-agent: *
+Disallow:


### PR DESCRIPTION
Same thing as https://github.com/yeoman/generator-angular/commit/fd942ce9a29b1f1fef645f61e6932140957d4d81.

According to the robots.txt standard:
>   The record starts with one or more User-agent lines, followed by one or more Disallow lines, as detailed below. "

This is also encouraged by the major search engines.
* Baidu:  http://www.baidu.com/search/robots_english.html
* Google: https://developers.google.com/webmasters/control-crawl-index/docs/getting_started and http://www.youtube.com/watch?v=P7GY1fE5JQQ

* Yandex: help.yandex.com/webmaster/controlling-robot/robots-txt.xml

Ref h5bp/html5-boilerplate#1487
       http://www.robotstxt.org/orig.html