### PR TITLE
update node-sass version

### DIFF
--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -26,7 +26,7 @@
     "grunt-requirejs": "^0.4.2",<% } %>
     "grunt-rev": "^0.1.0",
     "grunt-open": "^0.2.3",<% if (sassBootstrap) { %>
-    "grunt-sass": "^1.0.0",<% } %>
+    "grunt-sass": "^3.2.0",<% } %>
     "connect-livereload": "^0.4.0",
     "jit-grunt": "^0.9.1",
     "time-grunt": "^1.0.0",


### PR DESCRIPTION
i have a problem with current version node-sass.
So i update the version to 3.5.2
```
node-sass@1.2.3 postinstall /Users/nisum/test/node_modules/grunt-sass/node_modules/node-sass
> node scripts/build.js

`darwin-x64` exists; testing
module.js:355
  Module._extensions[extension](this, filename);
                               ^
Error: Module did not self-register.
    at Error (native)
    at Module.load (module.js:355:32)
    at Function.Module._load (module.js:310:12)
    at Module.require (module.js:365:17)
    at require (module.js:384:17)
    at Object.<anonymous> (/Users/nisum/test/node_modules/grunt-sass/node_modules/node-sass/lib/index.js:181:15)
    at Module._compile (module.js:460:26)
    at Object.Module._extensions..js (module.js:478:10)
    at Module.load (module.js:355:32)
    at Function.Module._load (module.js:310:12)
npm WARN prefer global bower@1.4.1 should be installed with -g
npm ERR! Darwin 13.4.0
npm ERR! argv "node" "/usr/local/bin/npm" "install"
npm ERR! node v0.12.0
npm ERR! npm  v2.13.3
npm ERR! code ELIFECYCLE

npm ERR! node-sass@1.2.3 postinstall: `node scripts/build.js`
npm ERR! Exit status 1
npm ERR!
npm ERR! Failed at the node-sass@1.2.3 postinstall script 'node scripts/build.js'.
npm ERR! This is most likely a problem with the node-sass package,
npm ERR! not with npm itself.
npm ERR! Tell the author that this fails on your system:
npm ERR!     node scripts/build.js
npm ERR! You can get their info via:
npm ERR!     npm owner ls node-sass
npm ERR! There is likely additional logging output above.

npm ERR! Please include the following file with any support request:
npm ERR!     /Users/nisum/test/npm-debug.log
```