### PR TITLE
Warn folks that node 0.12.x is not yet supported in currently release

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -4,6 +4,8 @@ A Backbone generator for Yeoman that provides a functional boilerplate Backbone 
 
 Optional RequireJS (AMD) support has recently been added as a prompt when using the generator on new projects.
 
+## Dependencies
+Currently depends on node 0.10.x until the next release.  Use the HEAD of master if you would like to use node 0.12.x. 
 
 ## Usage
 


### PR DESCRIPTION
Per #343 / #329 - Generating an app on a system with node 0.12.x will likely fail until [this pull request](https://github.com/yeoman/generator-backbone/commit/267ad5d475e74ba0568a6b9a292f7aef72d205b2) makes it into a release.