### PR TITLE
Updated yeoman-generator dependency to v0.20

### DIFF
--- a/all/index.js
+++ b/all/index.js
@@ -1,6 +1,8 @@
 var path = require('path');
 var util = require('util');
+var mkdirp = require('mkdirp');
 var yeoman = require('yeoman-generator');
+var pascalCase = require('pascal-case');
 
 var BackboneGenerator = yeoman.generators.Base.extend({
   constructor: function () {
@@ -8,7 +10,7 @@ var BackboneGenerator = yeoman.generators.Base.extend({
 
     this.argument('app_name', { type: String, required: false });
     this.appname = this.app_name || this.appname;
-    this.appname = this._.classify(this.appname);
+    this.appname = pascalCase(this.appname);
 
     this.env.options.appPath = this.options.appPath || 'app';
     this.config.set('appPath', this.env.options.appPath);
@@ -51,9 +53,10 @@ var BackboneGenerator = yeoman.generators.Base.extend({
 
   writing: {
     createDirLayout: function () {
+      var done = this.async();
       this.dirs.forEach(function (dir) {
         this.log.create('app/scripts/' + dir);
-        this.mkdir(path.join('app/scripts', dir));
+        mkdirp(path.join('app/scripts', dir), done);
       }.bind(this));
     },
 

--- a/app/templates/Gruntfile.js
+++ b/app/templates/Gruntfile.js
@@ -25,7 +25,7 @@ module.exports = function (grunt) {
 
   // configurable paths
   var yeomanConfig = {
-    app: '<%= env.options.appPath %>',
+    app: '<%= appPath %>',
     dist: 'dist'
   };
 
@@ -35,7 +35,7 @@ module.exports = function (grunt) {
       options: {
         nospawn: true,
         livereload: LIVERELOAD_PORT
-      },<% if (options.coffee) { %>
+      },<% if (hasCoffee) { %>
       coffee: {
         files: ['<%%= yeoman.app %>/scripts/{,*/}*.coffee'],
         tasks: ['coffee:dist']
@@ -147,7 +147,8 @@ module.exports = function (grunt) {
         '!<%%= yeoman.app %>/scripts/vendor/*',
         'test/spec/{,*/}*.js'
       ]
-    }<% if (testFramework === 'mocha') { %>,
+    },
+<% if (testFramework === 'mocha') { -%>
     mocha: {
       all: {
         options: {
@@ -155,10 +156,11 @@ module.exports = function (grunt) {
           urls: ['http://localhost:<%%= connect.test.options.port %>/index.html']
         }
       }
-    }<% } else { %>,
+    },
+<% } else { -%>
     jasmine: {
       all:{
-        src : '<%= yeoman.app %>/scripts/{,*/}*.js',
+        src : '<%%= yeoman.app %>/scripts/{,*/}*.js',
         options: {
           keepRunner: true,
           specs : 'test/spec/**/*.js',
@@ -170,7 +172,9 @@ module.exports = function (grunt) {
           ]
         }
       }
-    }<% } %>,<% if (options.coffee) { %>
+    },
+<% } -%>
+<% if (hasCoffee) { -%>
     coffee: {
       dist: {
         files: [{
@@ -192,7 +196,9 @@ module.exports = function (grunt) {
           ext: '.js'
         }]
       }
-    },<% } %><% if (sassBootstrap) { %>
+    },
+<% } -%>
+<% if (sassBootstrap) { -%>
     sass: {
       options: {
         sourceMap: true,
@@ -216,14 +222,22 @@ module.exports = function (grunt) {
           ext: '.css'
         }]
       }
-    },<% } %><% if (includeRequireJS) { %>
+    },
+<% } -%>
+<% if (includeRequireJS) { -%>
     requirejs: {
       dist: {
         // Options: https://github.com/jrburke/r.js/blob/master/build/example.build.js
-        options: {<% if (options.coffee) { %>
+        options: {
+<% if (hasCoffee) { -%>
           // `name` and `out` is set by grunt-usemin
-          baseUrl: '.tmp/scripts',<% } else { %>
-          baseUrl: '<%%= yeoman.app %>/scripts',<% } %>
+          baseUrl: '.tmp/scripts',
+<% } else { -%>
+          baseUrl: '<%%= yeoman.app %>/scripts',
+<% } -%>
+<% if (templateFramework !== 'handlebars') { -%>
+          wrap: true,
+<% } -%>
           optimize: 'none',
           paths: {
             'templates': '../../.tmp/scripts/templates',
@@ -237,18 +251,19 @@ module.exports = function (grunt) {
           // required to support SourceMaps
           // http://requirejs.org/docs/errors.html#sourcemapcomments
           preserveLicenseComments: false,
-          useStrict: true<% if (templateFramework !== 'handlebars') { %>,
-          wrap: true<% } %>
+          useStrict: true
           //uglify2: {} // https://github.com/mishoo/UglifyJS2
         }
       }
-    },<% } else { %>
+    },
+<% } else { -%>
     // not enabled since usemin task does concat and uglify
     // check index.html to edit your build targets
     // enable this task if you prefer defining your build targets here
     /*uglify: {
       dist: {}
-    },*/<% } %>
+    },*/
+<% } -%>
     useminPrepare: {
       html: '<%%= yeoman.app %>/index.html',
       options: {
@@ -313,53 +328,68 @@ module.exports = function (grunt) {
           src: [
             '*.{ico,txt}',
             'images/{,*/}*.{webp,gif}',
-            'styles/fonts/{,*/}*.*',<% if (sassBootstrap) { %>
-            'bower_components/bootstrap-sass-official/assets/fonts/bootstrap/*.*'<% } %>
+            'styles/fonts/{,*/}*.*',
+<% if (sassBootstrap) { -%>
+            'bower_components/bootstrap-sass-official/assets/fonts/bootstrap/*.*'
+<% } -%>
           ]
         }, {
           src: 'node_modules/apache-server-configs/dist/.htaccess',
           dest: '<%%= yeoman.dist %>/.htaccess'
         }]
       }
-    },<% if (includeRequireJS) { %>
+    },
+<% if (includeRequireJS) { -%>
     bower: {
       all: {
         rjsConfig: '<%%= yeoman.app %>/scripts/main.js'
       }
-    },<% } %><% if (templateFramework === 'mustache') { %>
+    },
+<% } -%>
+<% if (templateFramework === 'mustache') { -%>
     mustache: {
       files: {
         src: '<%%= yeoman.app %>/scripts/templates/',
         dest: '.tmp/scripts/templates.js',
-        options: {<% if (includeRequireJS) { %>
+        options: {
+<%   if (includeRequireJS) { -%>
           prefix: 'define(function() { this.JST = ',
-          postfix: '; return this.JST;});'<% } else { %>
+          postfix: '; return this.JST;});'
+<%   } else { -%>
           prefix: 'this.JST = ',
-          postfix: ';'<% } %>
+          postfix: ';'
+<%   } -%>
         }
       }
-    }<% } else if (templateFramework === 'handlebars') { %>
+    }
+<% } else if (templateFramework === 'handlebars') { -%>
     handlebars: {
       compile: {
         options: {
-          namespace: 'JST'<% if (includeRequireJS) { %>,
-          amd: true<% } %>
+<%   if (includeRequireJS) { -%>
+          amd: true,
+<%   } -%>
+          namespace: 'JST'
         },
         files: {
           '.tmp/scripts/templates.js': ['<%%= yeoman.app %>/scripts/templates/*.hbs']
         }
       }
-    }<% } else { %>
-    jst: {<% if (includeRequireJS) { %>
+    }
+<% } else { -%>
+    jst: {
+<%   if (includeRequireJS) { -%>
       options: {
         amd: true
-      },<% } %>
+      },
+<%   } -%>
       compile: {
         files: {
           '.tmp/scripts/templates.js': ['<%%= yeoman.app %>/scripts/templates/*.ejs']
         }
       }
-    }<% } %>,
+    },
+<% } -%>
     rev: {
       dist: {
         files: {
@@ -367,8 +397,10 @@ module.exports = function (grunt) {
             '<%%= yeoman.dist %>/scripts/{,*/}*.js',
             '<%%= yeoman.dist %>/styles/{,*/}*.css',
             '<%%= yeoman.dist %>/images/{,*/}*.{png,jpg,jpeg,gif,webp}',
-            '<%= yeoman.dist %>/styles/fonts/{,*/}*.*',<% if (sassBootstrap) { %>
-            'bower_components/bootstrap-sass-official/assets/fonts/bootstrap/*.*'<% } %>
+            '<%%= yeoman.dist %>/styles/fonts/{,*/}*.*',
+<% if (sassBootstrap) { -%>
+            'bower_components/bootstrap-sass-official/assets/fonts/bootstrap/*.*'
+<% } -%>
           ]
         }
       }
@@ -391,13 +423,21 @@ module.exports = function (grunt) {
 
     if (target === 'test') {
       return grunt.task.run([
-        'clean:server',<% if (options.coffee) { %>
-        'coffee',<% } %>
-        'createDefaultTemplate',<% if (templateFramework === 'mustache' ) { %>
-        'mustache',<% } else if (templateFramework === 'handlebars') { %>
-        'handlebars',<% } else { %>
-        'jst',<% } %><% if (sassBootstrap) { %>
-        'sass:server',<% } %>
+        'clean:server',
+<% if (hasCoffee) { -%>
+        'coffee',
+<% } -%>
+        'createDefaultTemplate',
+<% if (templateFramework === 'mustache' ) { -%>
+        'mustache',
+<% } else if (templateFramework === 'handlebars') { -%>
+        'handlebars',
+<% } else { -%>
+        'jst',
+<% } -%>
+<% if (sassBootstrap) { -%>
+        'sass:server',
+<% } -%>
         'connect:test',
         'open:test',
         'watch'
@@ -405,13 +445,21 @@ module.exports = function (grunt) {
     }
 
     grunt.task.run([
-      'clean:server',<% if (options.coffee) { %>
-      'coffee:dist',<% } %>
-      'createDefaultTemplate',<% if (templateFramework === 'mustache') { %>
-      'mustache',<% } else if (templateFramework === 'handlebars') { %>
-      'handlebars',<% } else { %>
-      'jst',<% } %><% if (sassBootstrap) { %>
-      'sass:server',<% } %>
+      'clean:server',
+<% if (hasCoffee) { -%>
+      'coffee:dist',
+<% } -%>
+      'createDefaultTemplate',
+<% if (templateFramework === 'mustache') { -%>
+      'mustache',
+<% } else if (templateFramework === 'handlebars') { -%>
+      'handlebars',
+<% } else { -%>
+      'jst',
+<% } -%>
+<% if (sassBootstrap) { -%>
+      'sass:server',
+<% } -%>
       'connect:livereload',
       'open:server',
       'watch'
@@ -421,16 +469,27 @@ module.exports = function (grunt) {
   grunt.registerTask('test', function (isConnected) {
     isConnected = Boolean(isConnected);
     var testTasks = [
-        'clean:server',<% if (options.coffee) { %>
-        'coffee',<% } %>
-        'createDefaultTemplate',<% if (templateFramework === 'mustache' ) { %>
-        'mustache',<% } else if (templateFramework === 'handlebars') { %>
-        'handlebars',<% } else { %>
-        'jst',<% } %><% if (sassBootstrap) { %>
-        'sass',<% } %><% if(testFramework === 'mocha') { %>
+        'clean:server',
+<% if (hasCoffee) { -%>
+        'coffee',
+<% } -%>
+        'createDefaultTemplate',
+<% if (templateFramework === 'mustache' ) { -%>
+        'mustache',
+<% } else if (templateFramework === 'handlebars') { -%>
+        'handlebars',
+<% } else { -%>
+        'jst',
+<% } -%>
+<% if (sassBootstrap) { -%>
+        'sass',
+<% } -%>
+<% if(testFramework === 'mocha') { -%>
         'connect:test',
-        'mocha',<% } else { %>
-        'jasmine'<% } %>
+        'mocha'
+<% } else { -%>
+        'jasmine'
+<% } -%>
       ];
 
     if(!isConnected) {
@@ -443,15 +502,25 @@ module.exports = function (grunt) {
   });
 
   grunt.registerTask('build', [
-    'clean:dist',<% if (options.coffee) { %>
-    'coffee',<% } %>
-    'createDefaultTemplate',<% if (templateFramework === 'mustache' ) { %>
-    'mustache',<% } else if (templateFramework === 'handlebars') { %>
-    'handlebars',<% } else { %>
-    'jst',<% } %><% if (sassBootstrap) { %>
-    'sass:dist',<% } %>
-    'useminPrepare',<% if (includeRequireJS) { %>
-    'requirejs',<% } %>
+    'clean:dist',
+<% if (hasCoffee) { -%>
+    'coffee',
+<% } -%>
+    'createDefaultTemplate',
+<% if (templateFramework === 'mustache' ) { -%>
+    'mustache',
+<% } else if (templateFramework === 'handlebars') { -%>
+    'handlebars',
+<% } else { -%>
+    'jst',
+<% } -%>
+<% if (sassBootstrap) { -%>
+    'sass:dist',
+<% } -%>
+    'useminPrepare',
+<% if (includeRequireJS) { -%>
+    'requirejs',
+<% } -%>
     'imagemin',
     'htmlmin',
     'concat',

--- a/app/templates/_bower.json
+++ b/app/templates/_bower.json
@@ -1,15 +1,21 @@
 {
-  "name": "<%= _.slugify(appname) %>",
+  "name": "<%= appSlugName %>",
   "version": "0.0.0",
-  "dependencies": {<% if (sassBootstrap) { %>
-    "bootstrap-sass-official": "~3.3.1",<% } %>
+  "dependencies": {
+<% if (sassBootstrap) { -%>
+    "bootstrap-sass-official": "~3.3.1",
+<% } -%>
     "jquery": "~2.1.0",
-    "lodash": "~2.4.1",
-    "backbone": "~1.1.0"<% if (includeRequireJS) { %>,
+    "backbone": "~1.1.0",
+<% if (includeRequireJS) { -%>
     "requirejs": "~2.1.10",
-    "requirejs-text": "~2.0.10"<% } if (includeModernizr) { %>,
-    "modernizr": "~2.7.1"<% } if (templateFramework === 'handlebars') { %>,
-    "handlebars": "~1.3.0"<% } %>
+    "requirejs-text": "~2.0.10",
+<% } if (includeModernizr) { -%>
+    "modernizr": "~2.7.1",
+<% } if (templateFramework === 'handlebars') { -%>
+    "handlebars": "~1.3.0"
+<% } -%>
+    "lodash": "~2.4.1"
   },
   "devDependencies": {}
 }

--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -1,16 +1,22 @@
 {
-  "name": "<%= _.slugify(appname) %>",
+  "name": "<%= appSlugName %>",
   "version": "0.0.0",
   "dependencies": {},
   "devDependencies": {
     "apache-server-configs": "^2.8.0",
     "grunt": "^0.4.5",
     "grunt-contrib-copy": "^0.5.0",
-    "grunt-contrib-concat": "^0.5.0",<% if (options.coffee) { %>
-    "grunt-contrib-coffee": "^0.11.0",<% } %><% if (templateFramework === 'mustache') { %>
-    "grunt-mustache": "^0.1.7",<% } else if (templateFramework === 'handlebars') { %>
-    "grunt-contrib-handlebars": "^0.8.0",<% } else { %>
-    "grunt-contrib-jst": "^0.6.0",<% } %>
+    "grunt-contrib-concat": "^0.5.0",
+<% if (hasCoffee) { -%>
+    "grunt-contrib-coffee": "^0.11.0",
+<% } -%>
+<% if (templateFramework === 'mustache') { -%>
+    "grunt-mustache": "^0.1.7",
+<% } else if (templateFramework === 'handlebars') { -%>
+    "grunt-contrib-handlebars": "^0.8.0",
+<% } else { -%>
+    "grunt-contrib-jst": "^0.6.0",
+<% } -%>
     "grunt-contrib-uglify": "^0.6.0",
     "grunt-contrib-jshint": "^0.10.0",
     "grunt-contrib-cssmin": "^0.10.0",
@@ -18,15 +24,22 @@
     "grunt-contrib-clean": "^0.6.0",
     "grunt-contrib-htmlmin": "^0.3.0",
     "grunt-contrib-imagemin": "^0.9.2",
-    "grunt-contrib-watch": "^0.6.1",<% if (testFramework === 'jasmine') { %>
-    "grunt-contrib-jasmine": "^0.8.0",<% }else{ %>
-    "grunt-mocha": "^0.4.11",<% } %>
-    "grunt-usemin": "^2.4.0",<% if(includeRequireJS){ %>
+    "grunt-contrib-watch": "^0.6.1",
+<% if (testFramework === 'jasmine') { -%>
+    "grunt-contrib-jasmine": "^0.8.0",
+<% }else{ -%>
+    "grunt-mocha": "^0.4.11",
+<% } -%>
+    "grunt-usemin": "^2.4.0",
+<% if(includeRequireJS){ -%>
     "grunt-bower-requirejs": "^1.1.0",
-    "grunt-requirejs": "^0.4.2",<% } %>
+    "grunt-requirejs": "^0.4.2",
+<% } -%>
     "grunt-rev": "^0.1.0",
-    "grunt-open": "^0.2.3",<% if (sassBootstrap) { %>
-    "grunt-sass": "^1.0.0",<% } %>
+    "grunt-open": "^0.2.3",
+<% if (sassBootstrap) { -%>
+    "grunt-sass": "^1.0.0",
+<% } -%>
     "connect-livereload": "^0.4.0",
     "jit-grunt": "^0.9.1",
     "time-grunt": "^1.0.0",

--- a/app/templates/app.coffee
+++ b/app/templates/app.coffee
@@ -1,4 +1,4 @@
-window.<%= _.camelize(appname) %> =
+window.<%= appSlugName %> =
   Models: {}
   Collections: {}
   Views: {}
@@ -9,4 +9,4 @@ window.<%= _.camelize(appname) %> =
 
 $ ->
   'use strict'
-  <%= _.camelize(appname) %>.init();
+  <%= appSlugName %>.init();

--- a/app/templates/app.js
+++ b/app/templates/app.js
@@ -1,7 +1,7 @@
-/*global <%= _.camelize(appname) %>, $*/
+/*global <%= appSlugName %>, $*/
 
 
-window.<%= _.camelize(appname) %> = {
+window.<%= appSlugName %> = {
   Models: {},
   Collections: {},
   Views: {},
@@ -14,5 +14,5 @@ window.<%= _.camelize(appname) %> = {
 
 $(document).ready(function () {
   'use strict';
-  <%= _.camelize(appname) %>.init();
+  <%= appSlugName %>.init();
 });

--- a/app/templates/bowerrc
+++ b/app/templates/bowerrc
@@ -1,3 +1,3 @@
 {
-  "directory": "<%= env.options.appPath %>/bower_components"
+  "directory": "<%= appPath %>/bower_components"
 }

--- a/app/templates/gitignore
+++ b/app/templates/gitignore
@@ -2,6 +2,6 @@ node_modules
 dist
 test/temp
 .sass-cache
-<%= env.options.appPath %>/bower_components
+<%= appPath %>/bower_components
 .tmp
 test/bower_components/

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -2,23 +2,24 @@
 <html class="no-js" lang="">
   <head>
     <meta charset="utf-8">
-    <title><%= appname %></title>
+    <title><%= appName %></title>
     <meta name="description" content="">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <!-- Place favicon.ico and apple-touch-icon.png in the root directory -->
     <!-- build:css(.tmp) styles/main.css -->
     <link rel="stylesheet" href="styles/main.css">
-    <!-- endbuild --><% if (includeModernizr) { %>
+    <!-- endbuild -->
+<% if (includeModernizr) { -%>
     <!-- build:js scripts/vendor/modernizr.js -->
     <script src="bower_components/modernizr/modernizr.js"></script>
-    <!-- endbuild --><% } %>
+    <!-- endbuild -->
+<% } -%>
   </head>
   <body>
     <!--[if lt IE 10]>
       <p class="browsehappy">You are using an <strong>outdated</strong> browser. Please <a href="http://browsehappy.com/">upgrade your browser</a> to improve your experience.</p>
     <![endif]-->
-
-    <% if (sassBootstrap) { %>
+<% if (sassBootstrap) { -%>
     <div class="container">
       <div class="header">
         <ul class="nav nav-pills pull-right">
@@ -26,7 +27,7 @@
           <li><a href="#">About</a></li>
           <li><a href="#">Contact</a></li>
         </ul>
-        <h3 class="text-muted"><%= appname %></h3>
+        <h3 class="text-muted"><%= appName %></h3>
       </div>
 
       <div class="jumbotron">
@@ -52,10 +53,11 @@
 
           <h4>Bootstrap</h4>
           <p>Sleek, intuitive, and powerful mobile first front-end framework for faster and easier web development.</p>
-          <% if (includeModernizr) { %>
+
+<% if (includeModernizr) { -%>
           <h4>Modernizr</h4>
           <p>Modernizr is an open-source JavaScript library that helps you build the next generation of HTML5 and CSS3-powered websites.</p>
-          <% } %>
+<% } -%>
         </div>
         <div class="col-lg-6">
           <h4>Backbone.js</h4>
@@ -64,9 +66,10 @@
           <h4>Lodash.js</h4>
           <p>A utility library delivering consistency, customization, performance, & extras. </p>
 
-          <% if (includeRequireJS) { %><h4>RequireJS</h4>
+<% if (includeRequireJS) { -%>
+          <h4>RequireJS</h4>
           <p>RequireJS is a JavaScript file and module loader. It is optimized for in-browser use, but it can be used in other JavaScript environments, like Rhino and Node.</p>
-          <% } %>
+<% } -%>
         </div>
       </div>
 
@@ -75,7 +78,7 @@
       </div>
 
     </div>
-    <% } else { // sassBootstrap %>
+<% } else { // sassBootstrap -%>
     <div class="hero-unit">
       <h1>'Allo, 'Allo!</h1>
       <p>You now have</p>
@@ -84,11 +87,16 @@
         <li>jQuery</li>
         <li>Backbone.js</li>
         <li>Lodash.js</li>
-        <% if (includeModernizr) { %><li>Modernizr</li><% } %>
-        <% if (includeRequireJS) { %><li>RequireJS</li><% } %>
+<% if (includeModernizr) { -%>
+        <li>Modernizr</li>
+<% } -%>
+<% if (includeRequireJS) { -%>
+        <li>RequireJS</li>
+<% } -%>
       </ul>
     </div>
-    <% } // sassBootstrap %>
+
+<% } // sassBootstrap -%>
 
     <!-- Google Analytics: change UA-XXXXX-X to be your site's ID. -->
     <script>

--- a/app/templates/jshintrc
+++ b/app/templates/jshintrc
@@ -17,8 +17,8 @@
   "strict": true,
   "jquery": true,
   "globals": {
-    "<%= appname %>": true,
-    "<%= _.slugify(appname) %>": true,
+    "<%= appName %>": true,
+    "<%= appSlugName %>": true,
     "_": false,
     "Backbone": false,
     "JST": false,
@@ -27,8 +27,10 @@
     "it": false,
     "assert": true,
     "expect": true,
-    "should": true<% if (includeRequireJS) { %>,
+    "should": true,
+<% if (includeRequireJS) { -%>
     "require": false,
-    "define": false<% } %>
+    "define": false
+<% } -%>
   }
 }

--- a/app/templates/requirejs_app.coffee
+++ b/app/templates/requirejs_app.coffee
@@ -2,19 +2,27 @@
 'use strict'
 
 require.config
-  shim: {<% if (sassBootstrap) { %>
+  shim: {
+<% if (sassBootstrap) { -%>
     bootstrap:
       deps: ['jquery'],
-      exports: 'jquery'<% } %><% if (templateFramework === 'handlebars') { %>
+      exports: 'jquery'
+<% } -%>
+<% if (templateFramework === 'handlebars') { -%>
     handlebars:
-      exports: 'Handlebars'<% } %>
+      exports: 'Handlebars'
+<% } -%>
   }
   paths:
     jquery: '../bower_components/jquery/dist/jquery'
     backbone: '../bower_components/backbone/backbone'
-    underscore: '../bower_components/lodash/dist/lodash'<% if (sassBootstrap) { %>
-    bootstrap: '../bower_components/bootstrap-sass-official/assets/javascripts/bootstrap'<% } %><% if (templateFramework === 'handlebars') { %>
-    handlebars: '../bower_components/handlebars/handlebars'<% } %>
+    underscore: '../bower_components/lodash/dist/lodash'
+<% if (sassBootstrap) { -%>
+    bootstrap: '../bower_components/bootstrap-sass-official/assets/javascripts/bootstrap'
+<% } -%>
+<% if (templateFramework === 'handlebars') { -%>
+    handlebars: '../bower_components/handlebars/handlebars'
+<% } -%>
 
 require [
   'backbone'

--- a/app/templates/requirejs_app.js
+++ b/app/templates/requirejs_app.js
@@ -2,21 +2,29 @@
 'use strict';
 
 require.config({
-  shim: {<% if (sassBootstrap) { %>
+  shim: {
+<% if (sassBootstrap) { -%>
     bootstrap: {
       deps: ['jquery'],
       exports: 'jquery'
-    }<% } %><% if (templateFramework === 'handlebars') { %>,
+    },
+<% } -%>
+<% if (templateFramework === 'handlebars') { -%>
       handlebars: {
       exports: 'Handlebars'
-    }<% } %>
+    }
+<% } -%>
   },
   paths: {
     jquery: '../bower_components/jquery/dist/jquery',
     backbone: '../bower_components/backbone/backbone',
-    underscore: '../bower_components/lodash/dist/lodash'<% if (sassBootstrap) { %>,
-    bootstrap: '../bower_components/bootstrap-sass-official/assets/javascripts/bootstrap'<% } %><% if (templateFramework === 'handlebars') { %>,
-    handlebars: '../bower_components/handlebars/handlebars'<% } %>
+    underscore: '../bower_components/lodash/dist/lodash'
+<% if (sassBootstrap) { -%>,
+    bootstrap: '../bower_components/bootstrap-sass-official/assets/javascripts/bootstrap'
+<% } -%>
+<% if (templateFramework === 'handlebars') { -%>,
+    handlebars: '../bower_components/handlebars/handlebars'
+<% } -%>
   }
 });
 

--- a/collection/index.js
+++ b/collection/index.js
@@ -1,6 +1,7 @@
 /*jshint latedef:false */
 var path = require('path');
 var util = require('util');
+var pascalCase = require('pascal-case');
 var yeoman = require('yeoman-generator');
 var scriptBase = require('../script-base');
 
@@ -14,7 +15,14 @@ var CollectionGenerator = scriptBase.extend({
 
   writing: {
     createControllerFiles: function () {
-      this._writeTemplate('collection', path.join(this.env.options.appPath + '/scripts/collections', this.name));
+      this._writeTemplate(
+        'collection',
+        path.join(this.env.options.appPath + '/scripts/collections', this.name),
+        {
+          appClassName: pascalCase(this.appname),
+          className: pascalCase(this.name)
+        }
+      );
 
       if (!this.options.requirejs) {
         this._addScriptToIndex('collections/' + this.name);

--- a/model/index.js
+++ b/model/index.js
@@ -1,6 +1,7 @@
 /*jshint latedef:false */
 var path = require('path');
 var util = require('util');
+var pascalCase = require('pascal-case');
 var yeoman = require('yeoman-generator');
 var scriptBase = require('../script-base');
 
@@ -16,7 +17,7 @@ var ModelGenerator = scriptBase.extend({
     });
 
     // parse back the attributes provided, build an array of attr
-    this.attrs = this.attributes.map(function (attr) {
+    this.attrs = this['attributes'].map(function (attr) {
       var parts = attr.split(':');
       return {
         name: parts[0],
@@ -27,7 +28,14 @@ var ModelGenerator = scriptBase.extend({
 
   writing: {
     createModelFiles: function () {
-      this._writeTemplate('model', path.join(this.env.options.appPath + '/scripts/models', this.name));
+      this._writeTemplate(
+        'model',
+        path.join(this.env.options.appPath, '/scripts/models', this.name),
+        {
+          appClassName: pascalCase(this.appname),
+          className: pascalCase(this.name)
+        }
+      );
 
       if (!this.options.requirejs) {
         this._addScriptToIndex('models/' + this.name);

--- a/package.json
+++ b/package.json
@@ -16,7 +16,12 @@
     "test": "mocha --reporter spec"
   },
   "dependencies": {
-    "yeoman-generator": "^0.17.0"
+    "ejs": "^2.3.0",
+    "html-wiring": "^1.0.0",
+    "mkdirp": "^0.5.0",
+    "pascal-case": "^1.1.0",
+    "param-case": "^1.1.0",
+    "yeoman-generator": "^0.20.0"
   },
   "peerDependencies": {
     "generator-mocha": ">=0.1.3",

--- a/router/index.js
+++ b/router/index.js
@@ -1,6 +1,7 @@
 /*jshint latedef:false */
 var path = require('path');
 var util = require('util');
+var pascalCase = require('pascal-case');
 var yeoman = require('yeoman-generator');
 var scriptBase = require('../script-base');
 
@@ -13,7 +14,14 @@ var RouterGenerator = scriptBase.extend({
 
   writing: {
     routerFiles: function () {
-      this._writeTemplate('router', path.join(this.env.options.appPath + '/scripts/routes', this.name));
+      this._writeTemplate(
+        'router',
+        path.join(this.env.options.appPath + '/scripts/routes', this.name),
+        {
+          appClassName: pascalCase(this.appname),
+          className: pascalCase(this.name)
+        }
+      );
 
       if (!this.options.requirejs) {
         this._addScriptToIndex('routes/' + this.name);

--- a/script-base.js
+++ b/script-base.js
@@ -26,13 +26,12 @@ var ScriptBase = yeoman.generators.NamedBase.extend({
       this.env.options.requirejs = this.options.requirejs;
     }
 
-    this._.mixin({ 'classify': backboneUtils.classify });
   },
 
   _addScriptToIndex: function (script) {
     try {
       var appPath = this.env.options.appPath;
-      var fullPath = path.join(appPath, 'index.html');
+      var fullPath = this.destinationPath(path.join(appPath, 'index.html'));
 
       backboneUtils.rewriteFile({
         file: fullPath,
@@ -63,9 +62,14 @@ var ScriptBase = yeoman.generators.NamedBase.extend({
   },
 
   _writeTemplate: function (source, destination, data) {
+
     this._setupSourceRootAndSuffix();
     var ext = this.scriptSuffix;
-    this.template(source + ext, destination + ext, data);
+    this.fs.copyTpl(
+      this.templatePath(source + ext),
+      this.destinationPath(destination + ext),
+      data
+    );
   },
 
   _canGenerateTests: function () {

--- a/templates/coffeescript/collection.coffee
+++ b/templates/coffeescript/collection.coffee
@@ -1,4 +1,4 @@
 'use strict';
 
-class <%= _.camelize(appname) %>.Collections.<%= _.classify(name) %> extends Backbone.Collection
-  model: <%= _.camelize(appname) %>.Models.<%= _.classify(name) %>
+class <%= appClassName %>.Collections.<%= className %> extends Backbone.Collection
+  model: <%= appClassName %>.Models.<%= className %>

--- a/templates/coffeescript/model.coffee
+++ b/templates/coffeescript/model.coffee
@@ -1,6 +1,6 @@
 'use strict';
 
-class <%= _.camelize(appname) %>.Models.<%= _.classify(name) %> extends Backbone.Model
+class <%= appClassName %>.Models.<%= className %> extends Backbone.Model
   url: '',
 
   initialize: () ->

--- a/templates/coffeescript/requirejs/collection.coffee
+++ b/templates/coffeescript/requirejs/collection.coffee
@@ -1,8 +1,8 @@
 define [
   'underscore'
   'backbone'
-  'models/<%= _.classify(name) %>-model'
-], (_, Backbone, <%= _.classify(name) %>Model) ->
+  'models/<%= className %>-model'
+], (_, Backbone, <%= className %>Model) ->
 
-  class <%= _.classify(name) %>Collection extends Backbone.Collection
-    model: <%= _.classify(name) %>Model
+  class <%= className %>Collection extends Backbone.Collection
+    model: <%= className %>Model

--- a/templates/coffeescript/requirejs/model.coffee
+++ b/templates/coffeescript/requirejs/model.coffee
@@ -4,7 +4,7 @@ define [
 ], (_, Backbone) ->
   'use strict';
 
-  class <%= _.classify(name) %>Model extends Backbone.Model
+  class <%= className %>Model extends Backbone.Model
     url: '',
 
     initialize: () ->

--- a/templates/coffeescript/requirejs/router.coffee
+++ b/templates/coffeescript/requirejs/router.coffee
@@ -1,5 +1,5 @@
 define [
   'backbone'
 ], (Backbone) ->
-  class <%= _.classify(name) %>Router extends Backbone.Router
+  class <%= className %>Router extends Backbone.Router
     routes: {}

--- a/templates/coffeescript/requirejs/view.coffee
+++ b/templates/coffeescript/requirejs/view.coffee
@@ -4,7 +4,7 @@ define [
   'backbone'
   'templates'
 ], ($, _, Backbone, JST) ->
-  class <%= _.classify(name) %>View extends Backbone.View
+  class <%= className %>View extends Backbone.View
     template: JST['<%= jst_path %>']
 
     tagName: 'div'

--- a/templates/coffeescript/router.coffee
+++ b/templates/coffeescript/router.coffee
@@ -1,3 +1,3 @@
 'use strict';
 
-class <%= _.camelize(appname) %>.Routers.<%= _.classify(name) %> extends Backbone.Router
+class <%= appClassName %>.Routers.<%= className %> extends Backbone.Router

--- a/templates/coffeescript/view.coffee
+++ b/templates/coffeescript/view.coffee
@@ -1,6 +1,6 @@
 'use strict';
 
-class <%= _.camelize(appname) %>.Views.<%= _.classify(name) %> extends Backbone.View
+class <%= appClassName %>.Views.<%= className %> extends Backbone.View
 
   template: JST['<%= jst_path %>']
 

--- a/templates/collection.js
+++ b/templates/collection.js
@@ -1,13 +1,13 @@
-/*global <%= _.camelize(appname) %>, Backbone*/
+/*global <%= appClassName %>, Backbone*/
 
-<%= _.camelize(appname) %>.Collections = <%= _.camelize(appname) %>.Collections || {};
+<%= appClassName %>.Collections = <%= appClassName %>.Collections || {};
 
 (function () {
   'use strict';
 
-  <%= _.camelize(appname) %>.Collections.<%= _.classify(name) %> = Backbone.Collection.extend({
+  <%= appClassName %>.Collections.<%= className %> = Backbone.Collection.extend({
 
-    model: <%= _.camelize(appname) %>.Models.<%= _.classify(name) %>
+    model: <%= appClassName %>.Models.<%= className %>
 
   });
 

--- a/templates/model.js
+++ b/templates/model.js
@@ -1,11 +1,11 @@
-/*global <%= _.camelize(appname) %>, Backbone*/
+/*global <%= appClassName %>, Backbone*/
 
-<%= _.camelize(appname) %>.Models = <%= _.camelize(appname) %>.Models || {};
+<%= appClassName %>.Models = <%= appClassName %>.Models || {};
 
 (function () {
   'use strict';
 
-  <%= _.camelize(appname) %>.Models.<%= _.classify(name) %> = Backbone.Model.extend({
+  <%= appClassName %>.Models.<%= className %> = Backbone.Model.extend({
 
     url: '',
 

--- a/templates/requirejs/collection.js
+++ b/templates/requirejs/collection.js
@@ -3,13 +3,13 @@
 define([
   'underscore',
   'backbone',
-  'models/<%= name %>'
-], function (_, Backbone, <%= _.classify(name) %>Model) {
+  'models/<%= className %>'
+], function (_, Backbone, <%= className %>Model) {
   'use strict';
 
-  var <%= _.classify(name) %>Collection = Backbone.Collection.extend({
-    model: <%= _.classify(name) %>Model
+  var <%= className %>Collection = Backbone.Collection.extend({
+    model: <%= className %>Model
   });
 
-  return <%= _.classify(name) %>Collection;
+  return <%= className %>Collection;
 });

--- a/templates/requirejs/model.js
+++ b/templates/requirejs/model.js
@@ -6,7 +6,7 @@ define([
 ], function (_, Backbone) {
   'use strict';
 
-  var <%= _.classify(name) %>Model = Backbone.Model.extend({
+  var <%= className %>Model = Backbone.Model.extend({
     url: '',
 
     initialize: function() {
@@ -23,5 +23,5 @@ define([
     }
   });
 
-  return <%= _.classify(name) %>Model;
+  return <%= className %>Model;
 });

--- a/templates/requirejs/router.js
+++ b/templates/requirejs/router.js
@@ -6,11 +6,11 @@ define([
 ], function ($, Backbone) {
   'use strict';
 
-  var <%= _.classify(name) %>Router = Backbone.Router.extend({
+  var <%= className %>Router = Backbone.Router.extend({
     routes: {
     }
 
   });
 
-  return <%= _.classify(name) %>Router;
+  return <%= className %>Router;
 });

--- a/templates/requirejs/view.js
+++ b/templates/requirejs/view.js
@@ -8,7 +8,7 @@ define([
 ], function ($, _, Backbone, JST) {
   'use strict';
 
-  var <%= _.classify(name) %>View = Backbone.View.extend({
+  var <%= className %>View = Backbone.View.extend({
     template: JST['<%= jst_path %>'],
 
     tagName: 'div',
@@ -28,5 +28,5 @@ define([
     }
   });
 
-  return <%= _.classify(name) %>View;
+  return <%= className %>View;
 });

--- a/templates/router.js
+++ b/templates/router.js
@@ -1,11 +1,11 @@
-/*global <%= _.camelize(appname) %>, Backbone*/
+/*global <%= appClassName %>, Backbone*/
 
-<%= _.camelize(appname) %>.Routers = <%= _.camelize(appname) %>.Routers || {};
+<%= appClassName %>.Routers = <%= appClassName %>.Routers || {};
 
 (function () {
   'use strict';
 
-  <%= _.camelize(appname) %>.Routers.<%= _.classify(name) %> = Backbone.Router.extend({
+  <%= appClassName %>.Routers.<%= className %> = Backbone.Router.extend({
 
   });
 

--- a/templates/view.js
+++ b/templates/view.js
@@ -1,11 +1,11 @@
-/*global <%= _.camelize(appname) %>, Backbone, JST*/
+/*global <%= appClassName %>, Backbone, JST*/
 
-<%= _.camelize(appname) %>.Views = <%= _.camelize(appname) %>.Views || {};
+<%= appClassName %>.Views = <%= appClassName %>.Views || {};
 
 (function () {
   'use strict';
 
-  <%= _.camelize(appname) %>.Views.<%= _.classify(name) %> = Backbone.View.extend({
+  <%= appClassName %>.Views.<%= className %> = Backbone.View.extend({
 
     template: JST['<%= jst_path %>'],
 

--- a/test/helper.js
+++ b/test/helper.js
@@ -1,24 +1,36 @@
 var yeoman  = require('yeoman-generator');
 var helpers = yeoman.test;
 var path    = require('path');
+var fs      = require('fs');
 
-exports.createSubGenerator = function (type, asserts) {
+exports.createSubGenerator = function (config, type, asserts) {
   var deps = [
     [helpers.createDummyGenerator(), 'backbone-mocha:' + type]
   ];
   helpers.run(path.join(__dirname, '../' + type))
+    .inDir(path.join(__dirname, 'temp'), function () {
+      fs.writeFileSync('.yo-rc.json', config);
+    })
     .withArguments(['foo'])
     .withGenerators(deps)
     .on('end', asserts);
 };
 
-exports.createAppGenerator = function (args, options) {
-  var app = helpers.createGenerator('backbone:app', [
-    '../../app', [
-      helpers.createDummyGenerator(),
-      'mocha:app'
-    ]
-  ], args, options);
-  app.options['skip-install'] = true;
-  return app;
+exports.createAppGenerator = function (config, prompts, done) {
+
+  prompts = prompts || { features: ['sassBootstrap']};
+
+  var options = { skipInstall: true };
+
+  var deps = [
+    [helpers.createDummyGenerator(), 'mocha:app']
+  ];
+  helpers.run(path.join(__dirname, '../app'))
+    .inDir(path.join(__dirname, 'temp'), function () {
+      fs.writeFileSync('.yo-rc.json', config);
+    })
+    .withPrompts(prompts)
+    .withOptions(options)
+    .withGenerators(deps)
+    .on('end', done);
 };

--- a/test/test-apppath.js
+++ b/test/test-apppath.js
@@ -7,34 +7,34 @@ var assert  = yeoman.assert;
 var fs      = require('fs');
 var test    = require('./helper.js');
 
+var config = [
+  '{',
+  '  "generator-backbone": {',
+  '    "appPath": "public",',
+  '    "appName": "Temp"',
+  '  }',
+  '}'
+].join('\n');
+
 describe('backbone generator with appPath option', function () {
   beforeEach(function (done) {
     var deps = [
       [helpers.createDummyGenerator(), 'mocha:app']
     ];
-    this.backbone = {};
-    this.backbone.app = helpers.run(path.join(__dirname, '../app'))
-      .inDir(path.join(__dirname, 'temp'), function () {
-        var out = [
-          '{',
-          '  "generator-backbone": {',
-          '    "appPath": "public",',
-          '    "appName": "Temp"',
-          '  }',
-          '}'
-        ];
-        fs.writeFileSync('.yo-rc.json', out.join('\n'));
+    helpers.run(path.join(__dirname, '../app'))
+      .inTmpDir(function () {
+        fs.writeFileSync('.yo-rc.json', config);
       })
       .withArguments(['temp'])
-      .withOptions({'skip-install': true, appPath: 'public'})
-      .withPrompt({features: ['sassBootstrap']})
-      .withGenerators(deps);
+      .withOptions({skipInstall: true, appPath: 'public'})
+      .withPrompts({features: ['sassBootstrap']})
+      .withGenerators(deps)
+      .on('end', done);
 
-    done();
   });
 
   describe('create expected files', function () {
-    it('in path specified by --appPath', function (done) {
+    it('in path specified by --appPath', function () {
       var expectedContent = [
         ['bower.json', /"name": "temp"/],
         ['package.json', /"name": "temp"/],
@@ -56,50 +56,40 @@ describe('backbone generator with appPath option', function () {
         'public/styles/main.scss'
       ];
 
-      this.backbone.app
-        .on('end', function () {
-          assert.file(expected);
-          assert.fileContent(expectedContent);
-          done();
-        });
+      assert.file(expected);
+      assert.fileContent(expectedContent);
     });
   });
 
   describe('creates model', function () {
     it('without failure', function (done) {
-      this.backbone.app.on('end', function () {
-        test.createSubGenerator('model', function () {
-          assert.fileContent(
-            'public/scripts/models/foo.js', /Models.Foo = Backbone.Model.extend\(\{/
-          );
-          done();
-        });
+      test.createSubGenerator(config, 'model', function () {
+        assert.fileContent(
+          'public/scripts/models/foo.js', /Models.Foo = Backbone.Model.extend\(\{/
+        );
+        done();
       });
     });
   });
 
   describe('creates collection', function () {
     it('without failure', function (done) {
-      this.backbone.app.on('end', function () {
-        test.createSubGenerator('collection', function () {
-          assert.fileContent(
-            'public/scripts/collections/foo.js', /Collections.Foo = Backbone.Collection.extend\(\{/
-          );
-          done();
-        });
+      test.createSubGenerator(config, 'collection', function () {
+        assert.fileContent(
+          'public/scripts/collections/foo.js', /Collections.Foo = Backbone.Collection.extend\(\{/
+        );
+        done();
       });
     });
   });
 
   describe('creates router', function () {
     it('without failure', function (done) {
-      this.backbone.app.on('end', function () {
-        test.createSubGenerator('router', function () {
-          assert.fileContent(
-            'public/scripts/routes/foo.js', /Routers.Foo = Backbone.Router.extend\(\{/
-          );
-          done();
-        });
+      test.createSubGenerator(config, 'router', function () {
+        assert.fileContent(
+          'public/scripts/routes/foo.js', /Routers.Foo = Backbone.Router.extend\(\{/
+        );
+        done();
       });
     });
   });
@@ -107,14 +97,12 @@ describe('backbone generator with appPath option', function () {
   describe('creates view', function () {
     it('without failure', function (done) {
 
-      this.backbone.app.on('end', function () {
-        test.createSubGenerator('view', function () {
-          assert.fileContent(
-            'public/scripts/views/foo.js', /Views.Foo = Backbone.View.extend\(\{(.|\n)*public\/scripts\/templates\/foo.ejs/
-          );
-          assert.file('public/scripts/templates/foo.ejs');
-          done();
-        });
+      test.createSubGenerator(config, 'view', function () {
+        assert.fileContent(
+          'public/scripts/views/foo.js', /Views.Foo = Backbone.View.extend\(\{(.|\n)*public\/scripts\/templates\/foo.ejs/
+        );
+        assert.file('public/scripts/templates/foo.ejs');
+        done();
       });
     });
   });

--- a/test/test-coffee-requirejs.js
+++ b/test/test-coffee-requirejs.js
@@ -7,34 +7,28 @@ var assert  = yeoman.assert;
 var fs      = require('fs');
 var test    = require('./helper.js');
 
+var config = [
+  '{',
+  '  "generator-backbone": {',
+  '    "appPath": "app",',
+  '    "appName": "Temp",',
+  '    "coffee": "true",',
+  '    "includeRequireJS": "true"',
+  '  }',
+  '}'
+].join('\n');
+
 describe('Backbone generator test with --coffee and --requirejs option', function () {
   beforeEach(function (done) {
-    helpers.testDirectory(path.join(__dirname, './temp'), function (err) {
-      if (err) {
-        return done(err);
-      }
-      this.backbone = {};
-      this.backbone.app = test.createAppGenerator();
 
-      helpers.mockPrompt(this.backbone.app, {
-        features: ['sassBootstrap', 'coffee', 'requirejs']
-      });
+    var prompts = {
+      features: ['sassBootstrap', 'coffee', 'requirejs']
+    };
 
-      var out = [
-        '{',
-        '  "generator-backbone": {',
-        '    "appPath": "app",',
-        '    "appName": "Temp"',
-        '  }',
-        '}'
-      ];
-      fs.writeFileSync('.yo-rc.json', out.join('\n'));
-
-      done();
-    }.bind(this));
+    test.createAppGenerator(config, prompts, done);
   });
 
-  it('creates expected files', function (done) {
+  it('creates expected files', function () {
     var expectedContent = [
       ['bower.json', /("name": "temp")(|.|\n)*(requirejs)/],
       ['package.json', /"name": "temp"/],
@@ -54,24 +48,19 @@ describe('Backbone generator test with --coffee and --requirejs option', functio
       'app/scripts/main.coffee'
     ];
 
-    this.backbone.app.run([], function () {
-      assert.file(expected);
-      assert.fileContent(expectedContent);
-      done();
-    });
+    assert.file(expected);
+    assert.fileContent(expectedContent);
 
   });
 
   describe('creates model in coffeescript with rjs', function () {
     it('without failure', function (done) {
 
-      this.backbone.app.run([], function () {
-        test.createSubGenerator('model', function () {
-          assert.fileContent(
-            'app/scripts/models/foo.coffee', /class FooModel extends Backbone.Model/
-          );
-          done();
-        });
+      test.createSubGenerator(config, 'model', function () {
+        assert.fileContent(
+          'app/scripts/models/foo.coffee', /class FooModel extends Backbone.Model/
+        );
+        done();
       });
     });
   });
@@ -79,13 +68,11 @@ describe('Backbone generator test with --coffee and --requirejs option', functio
   describe('creates collection in coffeescript with rjs', function () {
     it('without failure', function (done) {
 
-      this.backbone.app.run({}, function () {
-        test.createSubGenerator('collection', function () {
-          assert.fileContent(
-            'app/scripts/collections/foo.coffee', /class FooCollection extends Backbone.Collection/
-          );
-          done();
-        });
+      test.createSubGenerator(config, 'collection', function () {
+        assert.fileContent(
+          'app/scripts/collections/foo.coffee', /class FooCollection extends Backbone.Collection/
+        );
+        done();
       });
     });
   });
@@ -93,31 +80,27 @@ describe('Backbone generator test with --coffee and --requirejs option', functio
   describe('creates router in coffeescript with rjs', function () {
     it('without failure', function (done) {
 
-      this.backbone.app.run({}, function () {
-        test.createSubGenerator('router', function () {
-          assert.fileContent(
-            'app/scripts/routes/foo.coffee', /class FooRouter extends Backbone.Router/
-          );
-          done();
-        });
-
+      test.createSubGenerator(config, 'router', function () {
+        assert.fileContent(
+          'app/scripts/routes/foo.coffee', /class FooRouter extends Backbone.Router/
+        );
+        done();
       });
+
     });
   });
 
   describe('creates view in coffeescript with rjs', function () {
     it('without failure', function (done) {
 
-      this.backbone.app.run({}, function () {
-        test.createSubGenerator('view', function () {
-          assert.fileContent(
-            'app/scripts/views/foo.coffee', /class FooView extends Backbone.View(.|\n)*app\/scripts\/templates\/foo.ejs/
-          );
-          assert.file('app/scripts/templates/foo.ejs');
-          done();
-        });
-
+      test.createSubGenerator(config, 'view', function () {
+        assert.fileContent(
+          'app/scripts/views/foo.coffee', /class FooView extends Backbone.View(.|\n)*app\/scripts\/templates\/foo.ejs/
+        );
+        assert.file('app/scripts/templates/foo.ejs');
+        done();
       });
+
     });
   });
 

--- a/test/test-coffee.js
+++ b/test/test-coffee.js
@@ -7,34 +7,26 @@ var assert  = yeoman.assert;
 var fs      = require('fs');
 var test    = require('./helper.js');
 
+var config = [
+  '{',
+  '  "generator-backbone": {',
+  '    "appPath": "app",',
+  '    "appName": "Temp",',
+  '    "coffee": "true"',
+  '  }',
+  '}'
+].join('\n');
+
 describe('Backbone generator test with --coffee option', function () {
   beforeEach(function (done) {
-    helpers.testDirectory(path.join(__dirname, './temp'), function (err) {
-      if (err) {
-        return done(err);
-      }
-      this.backbone = {};
-      this.backbone.app = test.createAppGenerator();
+    var prompts = {
+      features: ['sassBootstrap', 'coffee']
+    };
 
-      helpers.mockPrompt(this.backbone.app, {
-        features: ['sassBootstrap', 'coffee']
-      });
-
-      var out = [
-        '{',
-        '  "generator-backbone": {',
-        '    "appPath": "app",',
-        '    "appName": "Temp"',
-        '  }',
-        '}'
-      ];
-      fs.writeFileSync('.yo-rc.json', out.join('\n'));
-
-      done();
-    }.bind(this));
+    test.createAppGenerator(config, prompts, done);
   });
 
-  it('creates expected files', function (done) {
+  it('creates expected files', function () {
     var expectedContent = [
       ['bower.json', /"name": "temp"/],
       ['package.json', /"name": "temp"/]
@@ -54,24 +46,19 @@ describe('Backbone generator test with --coffee option', function () {
       'app/scripts/main.coffee'
     ];
 
-    this.backbone.app.run([], function () {
-      assert.file(expected);
-      assert.fileContent(expectedContent);
-      done();
-    });
+    assert.file(expected);
+    assert.fileContent(expectedContent);
 
   });
 
   describe('creates model in coffeescript', function () {
     it('without failure', function (done) {
 
-      this.backbone.app.run([], function () {
-        test.createSubGenerator('model', function () {
-          assert.fileContent(
-            'app/scripts/models/foo.coffee', /class Temp.Models.Foo extends Backbone.Model/
-          );
-          done();
-        });
+      test.createSubGenerator(config, 'model', function () {
+        assert.fileContent(
+          'app/scripts/models/foo.coffee', /class Temp.Models.Foo extends Backbone.Model/
+        );
+        done();
       });
     });
   });
@@ -79,13 +66,11 @@ describe('Backbone generator test with --coffee option', function () {
   describe('creates collection in coffeescript', function () {
     it('without failure', function (done) {
 
-      this.backbone.app.run({}, function () {
-        test.createSubGenerator('collection', function () {
-          assert.fileContent(
-            'app/scripts/collections/foo.coffee', /class Temp.Collections.Foo extends Backbone.Collection/
-          );
-          done();
-        });
+      test.createSubGenerator(config, 'collection', function () {
+        assert.fileContent(
+          'app/scripts/collections/foo.coffee', /class Temp.Collections.Foo extends Backbone.Collection/
+        );
+        done();
       });
     });
   });
@@ -93,13 +78,11 @@ describe('Backbone generator test with --coffee option', function () {
   describe('creates router in coffeescript', function () {
     it('without failure', function (done) {
 
-      this.backbone.app.run({}, function () {
-        test.createSubGenerator('router', function () {
-          assert.fileContent(
-            'app/scripts/routes/foo.coffee', /class Temp.Routers.Foo extends Backbone.Router/
-          );
-          done();
-        });
+      test.createSubGenerator(config, 'router', function () {
+        assert.fileContent(
+          'app/scripts/routes/foo.coffee', /class Temp.Routers.Foo extends Backbone.Router/
+        );
+        done();
       });
     });
   });
@@ -107,14 +90,12 @@ describe('Backbone generator test with --coffee option', function () {
   describe('creates view in coffeescript', function () {
     it('without failure', function (done) {
 
-      this.backbone.app.run({}, function () {
-        test.createSubGenerator('view', function () {
-          assert.fileContent(
-            'app/scripts/views/foo.coffee', /class Temp.Views.Foo extends Backbone.View/
-          );
-          assert.file('app/scripts/templates/foo.ejs');
-          done();
-        });
+      test.createSubGenerator(config, 'view', function () {
+        assert.fileContent(
+          'app/scripts/views/foo.coffee', /class Temp.Views.Foo extends Backbone.View/
+        );
+        assert.file('app/scripts/templates/foo.ejs');
+        done();
       });
     });
   });

--- a/test/test-foo.js
+++ b/test/test-foo.js
@@ -7,31 +7,22 @@ var assert  = yeoman.assert;
 var fs      = require('fs');
 var test    = require('./helper.js');
 
+var config = [
+  '{',
+  '  "generator-backbone": {',
+  '    "appPath": "app",',
+  '    "appName": "Temp"',
+  '  }',
+  '}'
+].join('\n');
+
 describe('Backbone generator test', function () {
   beforeEach(function (done) {
-    helpers.testDirectory(path.join(__dirname, './temp'), function (err) {
-      if (err) {
-        return done(err);
-      }
-      this.backbone = {};
-      this.backbone.app = test.createAppGenerator();
+    var prompts = {
+      features: ['sassBootstrap']
+    };
 
-      helpers.mockPrompt(this.backbone.app, {
-        features: ['sassBootstrap']
-      });
-
-      var out = [
-        '{',
-        '  "generator-backbone": {',
-        '    "appPath": "app",',
-        '    "appName": "Temp"',
-        '  }',
-        '}'
-      ];
-      fs.writeFileSync('.yo-rc.json', out.join('\n'));
-
-      done();
-    }.bind(this));
+    test.createAppGenerator(config, prompts, done);
   });
 
   it('every generator can be required without throwing', function () {
@@ -45,7 +36,7 @@ describe('Backbone generator test', function () {
   });
 
   describe('create expected files', function () {
-    it('in path /app', function (done) {
+    it('in path /app', function () {
       var expectedContent = [
         ['bower.json', /"name": "temp"/],
         ['package.json', /"name": "temp"/]
@@ -66,24 +57,19 @@ describe('Backbone generator test', function () {
         'app/styles/main.scss'
       ];
 
-      this.backbone.app.run({}, function () {
-        assert.file(expected);
-        assert.fileContent(expectedContent);
-        done();
-      });
+      assert.file(expected);
+      assert.fileContent(expectedContent);
     });
   });
 
   describe('creates backbone model', function () {
     it('without failure', function (done) {
 
-      this.backbone.app.run({}, function () {
-        test.createSubGenerator('model', function () {
-          assert.fileContent(
-            'app/scripts/models/foo.js', /Models.Foo = Backbone.Model.extend\(\{/
-          );
-          done();
-        });
+      test.createSubGenerator(config, 'model', function () {
+        assert.fileContent(
+          'app/scripts/models/foo.js', /Models.Foo = Backbone.Model.extend\(\{/
+        );
+        done();
       });
     });
   });
@@ -91,13 +77,11 @@ describe('Backbone generator test', function () {
   describe('creates backbone collection', function () {
     it('without failure', function (done) {
 
-      this.backbone.app.run({}, function () {
-        test.createSubGenerator('collection', function () {
-          assert.fileContent(
-            'app/scripts/collections/foo.js', /Collections.Foo = Backbone.Collection.extend\(\{/
-          );
-          done();
-        });
+      test.createSubGenerator(config, 'collection', function () {
+        assert.fileContent(
+          'app/scripts/collections/foo.js', /Collections.Foo = Backbone.Collection.extend\(\{/
+        );
+        done();
       });
     });
   });
@@ -105,13 +89,11 @@ describe('Backbone generator test', function () {
   describe('creates backbone router', function () {
     it('without failure', function (done) {
 
-      this.backbone.app.run({}, function () {
-        test.createSubGenerator('router', function () {
-          assert.fileContent(
-            'app/scripts/routes/foo.js', /Routers.Foo = Backbone.Router.extend\(\{/
-          );
-          done();
-        });
+      test.createSubGenerator(config, 'router', function () {
+        assert.fileContent(
+          'app/scripts/routes/foo.js', /Routers.Foo = Backbone.Router.extend\(\{/
+        );
+        done();
       });
     });
   });
@@ -119,14 +101,12 @@ describe('Backbone generator test', function () {
   describe('creates backbone view', function () {
     it('without failure', function (done) {
 
-      this.backbone.app.run({}, function () {
-        test.createSubGenerator('view', function () {
-          assert.fileContent(
-            'app/scripts/views/foo.js', /Views.Foo = Backbone.View.extend\(\{(.|\n)*app\/scripts\/templates\/foo.ejs/
-          );
-          assert.file('app/scripts/templates/foo.ejs');
-          done();
-        });
+      test.createSubGenerator(config, 'view', function () {
+        assert.fileContent(
+          'app/scripts/views/foo.js', /Views.Foo = Backbone.View.extend\(\{(.|\n)*app\/scripts\/templates\/foo.ejs/
+        );
+        assert.file('app/scripts/templates/foo.ejs');
+        done();
       });
     });
   });

--- a/test/test-handlebars.js
+++ b/test/test-handlebars.js
@@ -7,47 +7,27 @@ var assert  = yeoman.assert;
 var fs      = require('fs');
 var test    = require('./helper.js');
 
+var config = [
+  '{',
+  '  "generator-backbone": {',
+  '    "appPath": "app",',
+  '    "appName": "Temp",',
+  '    "templateFramework": "handlebars"',
+  '  }',
+  '}'
+].join('\n');
+
 describe('Backbone generator with handlebars', function () {
-  beforeEach(function (done) {
-    helpers.testDirectory(path.join(__dirname, './temp'), function (err) {
-      if (err) {
-        return done(err);
-      }
-      this.backbone = {};
-      this.backbone.app = test.createAppGenerator(['temp'], {'template-framework': 'handlebars'});
-
-      helpers.mockPrompt(this.backbone.app, {
-        features: ['sassBootstrap'],
-        includeRequireJS: false
-      });
-
-      var out = [
-        '{',
-        '  "generator-backbone": {',
-        '    "appPath": "app",',
-        '    "appName": "Temp",',
-        '    "templateFramework": "handlebars"',
-        '  }',
-        '}'
-      ];
-      fs.writeFileSync('.yo-rc.json', out.join('\n'));
-
-      done();
-    }.bind(this));
-
-  });
 
   describe('creates backbone view', function () {
     it('without failure', function (done) {
 
-      this.backbone.app.run({}, function () {
-        test.createSubGenerator('view', function () {
-          assert.fileContent(
-            'app/scripts/views/foo.js', /Views.Foo = Backbone.View.extend\(\{(.|\n)*app\/scripts\/templates\/foo.hbs/
-          );
-          assert.file('app/scripts/templates/foo.hbs');
-          done();
-        });
+      test.createSubGenerator(config, 'view', function () {
+        assert.fileContent(
+          'app/scripts/views/foo.js', /Views.Foo = Backbone.View.extend\(\{(.|\n)*app\/scripts\/templates\/foo.hbs/
+        );
+        assert.file('app/scripts/templates/foo.hbs');
+        done();
       });
     });
   });

--- a/test/test-mustache.js
+++ b/test/test-mustache.js
@@ -7,46 +7,26 @@ var assert  = yeoman.assert;
 var fs      = require('fs');
 var test    = require('./helper.js');
 
+var config = [
+  '{',
+  '  "generator-backbone": {',
+  '    "appPath": "app",',
+  '    "appName": "Temp",',
+  '    "templateFramework": "mustache"',
+  '  }',
+  '}'
+].join('\n');
+
 describe('Backbone generator with mustache', function () {
-  beforeEach(function (done) {
-    helpers.testDirectory(path.join(__dirname, './temp'), function (err) {
-      if (err) {
-        return done(err);
-      }
-      this.backbone = {};
-      this.backbone.app = test.createAppGenerator(['temp'], {'template-framework': 'mustache'});
-
-      helpers.mockPrompt(this.backbone.app, {
-        features: ['sassBootstrap'],
-        includeRequireJS: false
-      });
-
-      var out = [
-        '{',
-        '  "generator-backbone": {',
-        '    "appPath": "app",',
-        '    "appName": "Temp",',
-        '    "templateFramework": "mustache"',
-        '  }',
-        '}'
-      ];
-      fs.writeFileSync('.yo-rc.json', out.join('\n'));
-
-      done();
-    }.bind(this));
-
-  });
 
   it('creates backbone view', function (done) {
 
-    this.backbone.app.run({}, function () {
-      test.createSubGenerator('view', function () {
-        assert.fileContent(
-          'app/scripts/views/foo.js', /Views.Foo = Backbone.View.extend\(\{(.|\n)*foo-template/
-        );
-        assert.file('app/scripts/templates/foo-template.mustache');
-        done();
-      });
+    test.createSubGenerator(config, 'view', function () {
+      assert.fileContent(
+        'app/scripts/views/foo.js', /Views.Foo = Backbone.View.extend\(\{(.|\n)*foo-template/
+      );
+      assert.file('app/scripts/templates/foo-template.mustache');
+      done();
     });
   });
 });

--- a/test/test-requirejs.js
+++ b/test/test-requirejs.js
@@ -7,36 +7,27 @@ var assert  = yeoman.assert;
 var fs      = require('fs');
 var test    = require('./helper.js');
 
+var config = [
+  '{',
+  '  "generator-backbone": {',
+  '    "appPath": "app",',
+  '    "appName": "Temp",',
+  '    "includeRequireJS": "true"',
+  '  }',
+  '}'
+].join('\n');
+
 describe('Backbone generator with RequireJS', function () {
+
   beforeEach(function (done) {
-    helpers.testDirectory(path.join(__dirname, './temp'), function (err) {
-      if (err) {
-        return done(err);
-      }
-      this.backbone = {};
-      this.backbone.app = test.createAppGenerator();
-
-      helpers.mockPrompt(this.backbone.app, {
-        features: ['sassBootstrap', 'requirejs']
-      });
-
-      var out = [
-        '{',
-        '  "generator-backbone": {',
-        '    "appPath": "app",',
-        '    "appName": "Temp"',
-        '  }',
-        '}'
-      ];
-      fs.writeFileSync('.yo-rc.json', out.join('\n'));
-
-      done();
-    }.bind(this));
-
+    var prompts = {
+      features: ['sassBootstrap', 'requirejs']
+    };
+    test.createAppGenerator(config, prompts, done);
   });
 
   describe('creates expected files', function () {
-    it('with sassBootstrap', function (done) {
+    it('with sassBootstrap', function () {
       var expectedContent = [
         ['bower.json', /("name": "temp")(|.|\n)*(requirejs)/],
         ['package.json', /"name": "temp"/],
@@ -55,15 +46,12 @@ describe('Backbone generator with RequireJS', function () {
         '.editorconfig'
       ];
 
-      this.backbone.app.run({}, function () {
-        assert.file(expected);
-        assert.fileContent(expectedContent);
-        done();
-      });
+      assert.file(expected);
+      assert.fileContent(expectedContent);
 
     });
 
-    it('without sassBootstrap', function (done) {
+    it('without sassBootstrap', function () {
       var expectedContent = [
         ['bower.json', /("name": "temp")(|.|\n)*(requirejs)/],
         ['package.json', /"name": "temp"/],
@@ -84,63 +72,52 @@ describe('Backbone generator with RequireJS', function () {
         'package.json'
       ];
 
-      this.backbone.app.run({}, function () {
-        assert.file(expected);
-        assert.fileContent(expectedContent);
-        done();
-      });
+      assert.file(expected);
+      assert.fileContent(expectedContent);
     });
   });
 
   describe('creates model', function () {
     it('without failure', function (done) {
-      this.backbone.app.run({}, function () {
-        test.createSubGenerator('model', function () {
-          assert.fileContent(
-            'app/scripts/models/foo.js', /var FooModel = Backbone.Model.extend\(\{/
-          );
-          done();
-        });
+      test.createSubGenerator(config, 'model', function () {
+        assert.fileContent(
+          'app/scripts/models/foo.js', /var FooModel = Backbone.Model.extend\(\{/
+        );
+        done();
       });
     });
   });
 
   describe('creates collection', function () {
     it('without failure', function (done) {
-      this.backbone.app.run({}, function () {
-        test.createSubGenerator('collection', function () {
-          assert.fileContent(
-            'app/scripts/collections/foo.js', /var FooCollection = Backbone.Collection.extend\(\{/
-          );
-          done();
-        });
+      test.createSubGenerator(config, 'collection', function () {
+        assert.fileContent(
+          'app/scripts/collections/foo.js', /var FooCollection = Backbone.Collection.extend\(\{/
+        );
+        done();
       });
     });
   });
 
   describe('creates router', function () {
     it('without failure', function (done) {
-      this.backbone.app.run({}, function () {
-        test.createSubGenerator('router', function () {
-          assert.fileContent(
-            'app/scripts/routes/foo.js', /var FooRouter = Backbone.Router.extend\(\{/
-          );
-          done();
-        });
+      test.createSubGenerator(config, 'router', function () {
+        assert.fileContent(
+          'app/scripts/routes/foo.js', /var FooRouter = Backbone.Router.extend\(\{/
+        );
+        done();
       });
     });
   });
 
   describe('creates backbone view', function () {
     it('without failure', function (done) {
-      this.backbone.app.run({}, function () {
-        test.createSubGenerator('view', function () {
-          assert.fileContent(
-            'app/scripts/views/foo.js', /var FooView = Backbone.View.extend\(\{(.|\n)*app\/scripts\/templates\/foo.ejs/
-          );
-          assert.file('app/scripts/templates/foo.ejs');
-          done();
-        });
+      test.createSubGenerator(config, 'view', function () {
+        assert.fileContent(
+          'app/scripts/views/foo.js', /var FooView = Backbone.View.extend\(\{(.|\n)*app\/scripts\/templates\/foo.ejs/
+        );
+        assert.file('app/scripts/templates/foo.ejs');
+        done();
       });
     });
   });

--- a/view/index.js
+++ b/view/index.js
@@ -1,6 +1,7 @@
 /*jshint latedef:false */
 var path = require('path');
 var util = require('util');
+var pascalCase = require('pascal-case');
 var yeoman = require('yeoman-generator');
 var scriptBase = require('../script-base');
 
@@ -28,7 +29,15 @@ var ViewGenerator = scriptBase.extend({
         this.jst_path = this.name + '-template';
       }
 
-      this._writeTemplate('view', path.join(this.env.options.appPath + '/scripts/views', this.name));
+      this._writeTemplate(
+        'view',
+        path.join(this.env.options.appPath + '/scripts/views', this.name),
+        {
+          appClassName: pascalCase(this.appname),
+          className: pascalCase(this.name),
+          'jst_path': this.jst_path
+        }
+      );
 
       if (!this.options.requirejs) {
         this._addScriptToIndex('views/' + this.name);


### PR DESCRIPTION
Updated the `yeoman-generator` to use the **v0.20**+ API

- Migrated to new `mem-fs-editor` methods
- Fixed deprecation warnings
- Added new required dependencies: `ejs`, `mkdirp`, `htmlWiring`
- Updated templates
- Updated tests and its helpers

ping @arthurvr 