### PR TITLE
backbone:all shouldn't invoke backbone:app, fixes #214

### DIFF
--- a/generators/all/index.js
+++ b/generators/all/index.js
@@ -58,10 +58,6 @@ var BackboneGenerator = yeoman.generators.Base.extend({
         this.log.create('app/scripts/' + dir);
         mkdirp(path.join('app/scripts', dir), done);
       }.bind(this));
-    },
-
-    composeSubGenerators: function () {
-      this.composeWith('backbone:app', {arguments: this.args});
     }
   },
 

--- a/test/helper.js
+++ b/test/helper.js
@@ -3,10 +3,8 @@ var helpers = yeoman.test;
 var path    = require('path');
 var fs      = require('fs');
 
-exports.createSubGenerator = function (config, type, asserts) {
-  var deps = [
-    [helpers.createDummyGenerator(), 'backbone-mocha:' + type]
-  ];
+exports.createSubGenerator = function (config, type, asserts, deps) {
+  deps = deps || [];
   helpers.run(path.join(__dirname, '../generators/' + type))
     .inDir(path.join(__dirname, 'temp'), function () {
       fs.writeFileSync('.yo-rc.json', config);

--- a/test/test-foo.js
+++ b/test/test-foo.js
@@ -110,4 +110,44 @@ describe('Backbone generator test', function () {
     });
   });
 
+  describe('creates backbone all', function () {
+    it('without failure', function (done) {
+
+      // mocks composed generators to test for their execution
+      var hasBeenCalled = {};
+      var depNames = [
+        'backbone:model',
+        'backbone:collection',
+        'backbone:router',
+        'backbone:view'
+      ];
+      var deps = depNames.map(function (name) {
+        return [
+          yeoman.Base.extend({
+            exec: function () {
+              hasBeenCalled[name] = true;
+              testDepsBeenCalled();
+            }
+          }),
+          name
+        ];
+      });
+
+      // tests that all dependencies have been called, will timeout otherwise
+      var testDepsBeenCalled = function () {
+        var allDepsCalled = depNames.every(function (name) {
+          return hasBeenCalled[name];
+        });
+        if (allDepsCalled) {
+          assert(true);
+          done();
+        }
+      };
+
+      // runs backbone:all generator
+      test.createSubGenerator(config, 'all', testDepsBeenCalled, deps);
+    });
+  });
+
+
 });


### PR DESCRIPTION
`backbone:all` had this weird composition where it would try to invoke `backbone:app`, that would just completely break the expected behavior as described on #214 

This PR fixes it by just removing the rogue composition with `backbone:app` altogether.

@arthurvr 