### PR TITLE
Fix script tags not being added to index file

### DIFF
--- a/util.js
+++ b/util.js
@@ -44,13 +44,10 @@ function rewrite(args) {
 }
 
 function rewriteFile(args) {
-  args.path = args.path || process.cwd();
-  var fullPath = path.join(args.path, args.file);
-
-  args.haystack = fs.readFileSync(fullPath, 'utf8');
+  args.haystack = fs.readFileSync(args.file, 'utf8');
   var body = rewrite(args);
 
-  fs.writeFileSync(fullPath, body);
+  fs.writeFileSync(args.file, body);
 }
 
 module.exports = {


### PR DESCRIPTION
the logic on `util.rewriteFiles` slipped through the new yeoman api migration and files weren't added to `index.html` as a result.

This rewrites the logic of the function to work along with the new API and fixes #364