### PR TITLE
Fixes small uglify build issue

### DIFF
--- a/generators/app/templates/Gruntfile.js
+++ b/generators/app/templates/Gruntfile.js
@@ -529,8 +529,8 @@ module.exports = function (grunt) {
     'cssmin',
 <% if (includeRequireJS) { -%>
     'requirejs',
-    'uglify',
 <% } -%>
+    'uglify',
     'copy',
     'rev',
     'usemin'


### PR DESCRIPTION
@marian-r I'm not sure if this change from #372 was intentional but it ended up breaking the javascript build for projects generated not using **requirejs**.

Let me know if there was a reason for doing so.