### PR TITLE
Fixes bower install on app generator

### DIFF
--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -396,8 +396,14 @@ var BackboneGenerator = yeoman.generators.Base.extend({
   },
 
   install: function () {
-    if (['backbone:app', 'backbone'].indexOf(this.options.namespace) >= 0) {
-      this.installDependencies({ skipInstall: this.options['skip-install'] });
+    var shouldInstall = !this.options['skip-install'];
+    var isInstallable = ['backbone:app', 'backbone'].indexOf(this.options.namespace) > -1;
+    if (shouldInstall && isInstallable) {
+      this.npmInstall();
+      this.bowerInstall('', {
+        'config.cwd': this.destinationPath('.'),
+        'config.directory': path.join(this.config.get('appPath'), 'bower_components')
+      });
     }
   }
 });


### PR DESCRIPTION
Bower install has been broken for a long time in this generator, as reported on #298 - I managed to track it down to the composition with the Mocha generator, that generator also creates a `.bowerrc` file that it leaves on the `test` folder, Bower was using that folder as the main application folder [because it prioritizes config files upwards in the directory tree](http://bower.io/docs/config/#placement--order).

This PR fixes the issue by setting Bower config arguments on `bowerInstall`

@SBoudrias maybe you can find some time to review it? :blush: 