### PR TITLE
fixed #386 Subtemplates not using requirejs

### DIFF
--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -58,7 +58,7 @@ var BackboneGenerator = yeoman.generators.Base.extend({
       testFramework: this.testFramework,
       templateFramework: this.templateFramework,
       sassBootstrap: this.sassBootstrap,
-      includeRequireJS: this.includeRequireJS
+      includeRequireJS: this.options.requirejs
     });
 
     this.indexFile = htmlWiring.readFileAsString(this.templatePath('index.html'));


### PR DESCRIPTION
fixed following @eddiemonge and verified manually, tried to add a failing unit test before but couldn't make it as the current createAppGenerator test helper relies on creating the .yo-rc.json config as a way to set the parameters which is actually what we want to test